### PR TITLE
timeout for database initialization job configurable by helm values file

### DIFF
--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 name: thingsboard
 description: A Helm chart for Thingsboard
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 3.3.4.1
 icon: https://avatars.githubusercontent.com/u/24291394?s=200&v=4
 home: https://github.com/thingsboard/thingsboard-ce-k8s/

--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -19,7 +19,7 @@ name: thingsboard
 description: A Helm chart for Thingsboard
 type: application
 version: 0.1.3
-appVersion: 3.3.4.1
+appVersion: 3.4.1
 icon: https://avatars.githubusercontent.com/u/24291394?s=200&v=4
 home: https://github.com/thingsboard/thingsboard-ce-k8s/
 dependencies:

--- a/helm/thingsboard/templates/initializedb-job.yaml
+++ b/helm/thingsboard/templates/initializedb-job.yaml
@@ -30,7 +30,7 @@ spec:
         - name: check-db-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }};
+            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -t {{ .Values.initializedb.check.timeout }};
             do echo waiting for database; sleep 2; done;']
       containers:
       - name: init-db

--- a/helm/thingsboard/templates/initializedb-job.yaml
+++ b/helm/thingsboard/templates/initializedb-job.yaml
@@ -30,7 +30,7 @@ spec:
         - name: check-db-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -t {{ .Values.initializedb.check.timeout }};
+            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
             do echo waiting for database; sleep 2; done;']
       containers:
       - name: init-db

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -304,3 +304,7 @@ kafka:
   zookeeper:
     persistence:
       enabled: false
+initializedb:
+  check:
+    # default value of the timeout for the pg_isready command
+    timeout: 3

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -257,6 +257,12 @@ cassandraInitDB:
     class: SimpleStrategy
     factor: 1
 
+postgresInitDB:
+  job:
+    check:
+      # default value of the timeout for the pg_isready command
+      timeout: 3
+
 cassandra:
   # Database can be either postgres or hybrid (entities in postgres and timeseries in cassandra)
   # for an postgresql database set cassandra.enabled as false
@@ -304,7 +310,4 @@ kafka:
   zookeeper:
     persistence:
       enabled: false
-initializedb:
-  check:
-    # default value of the timeout for the pg_isready command
-    timeout: 3
+

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -17,7 +17,7 @@
 global:
   image:
     server: docker.io
-    tag: "3.3.4.1"
+    tag: "3.4.1"
     pullSecrets: []
     pullPolicy: Always
   jsonLogs: false


### PR DESCRIPTION
I am deploying thingsboard into a kind cluster running locally in my laptop and the initialize database job takes a lot of time to complete just because checking the status of the database takes more than 3 seconds.
Being able to set up this timeout using values helped me to finally start the chart without further issues. I set up the default value for the timeout in the values to be backward compatible.

find out more details at: https://www.postgresql.org/docs/current/app-pg-isready.html#:~:text=The%20default%20is%203%20seconds.

This PR was created into thingsboard repository too but there is no feedback from them for this small change.