### PR TITLE
EVP-2115. initialization job can install or update the database

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -65,6 +65,13 @@ helm install --create-namespace -n thingsboard thingsboard thingsboard \
   --set mqtt.ssl.enabled=true \
   --set mqtt.ssl.secret=mqtt-tls-secret \
 ```
+* Upgrade database
+```
+helm upgrade -n thingsboard thingsboard thingsboard \
+  --set initDBJob.operation=upgrade \
+  --set initDBJob.fromVersion=1.2.3
+```
+
 ## All options
 * For the full list of options of this helm chart:
 ```

--- a/helm/thingsboard/templates/initializedb-job.yaml
+++ b/helm/thingsboard/templates/initializedb-job.yaml
@@ -47,10 +47,15 @@ spec:
           - "-c"
           - "start-tb-node.sh"
         env:
-        - name: INSTALL_TB
+        - name: {{ .Values.initDBJob.operation | upper }}_TB
           value: "true"
         - name: LOAD_DEMO
           value: "{{ .Values.node.loadDemo }}"
+        {{- if .Values.initDBJob.fromVersion }}
+        - name: FROM_VERSION
+          value: "{{ .Values.initDBJob.fromVersion }}"
+        {{- end}}
+        
       restartPolicy: Never
       volumes:
         - name: '{{ .Release.Name }}-node-config'

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -43,7 +43,8 @@ ingress:
     - chart-example.local
   # Enable or disable tls, same host as above
   tls: false
-  
+
+
 
 node:
   # kind can be either Deployment or StatefulSet
@@ -256,6 +257,15 @@ cassandraInitDB:
   replication:
     class: SimpleStrategy
     factor: 1
+
+initDBJob:
+  # set 'operation' to 'install' to create database
+  # and set to 'upgrade' to update the database to latest version
+  # starting at 'fromVersion' 
+  operation: "install"
+  # with the current version of the database for triggering the
+  # upgrade. 
+  fromVersion: ""
 
 postgresInitDB:
   job:


### PR DESCRIPTION
The Helm chart of TBu always installs the database. Therefore we are not being able to upgrade the database after the first install. 
Some parameters are added into the helm chart in order to setup the install of upgrade behavior. 