### PR TITLE
[EVP-2054] Add configuration to overwrite default root chain.

### DIFF
--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -99,6 +99,11 @@ spec:
               name: {{ .Release.Name }}-node-config
             - mountPath: /var/log/thingsboard
               name: {{ .Release.Name }}-node-logs
+{{- if .Values.node.ruleChain.configmapName }}
+            - mountPath: /usr/share/thingsboard/data/json/tenant/rule_chains/root_rule_chain.json
+              subPath: root_rule_chain.json
+              name: {{ .Values.node.ruleChain.configmapName }}
+{{- end}}
           readinessProbe:
             httpGet:
               path: /login
@@ -122,6 +127,14 @@ spec:
               path:  logback.xml
         - name: {{ .Release.Name }}-node-logs
           emptyDir: {}
+{{- if .Values.node.ruleChain.configmapName }}
+        - name: {{ .Values.node.ruleChain.configmapName }}
+          configMap:
+            name: {{ .Values.node.ruleChain.configmapName }}
+            items:
+            - key: rule_chain
+              path: root_rule_chain.json
+{{- end}}
       {{- with .Values.node.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -93,6 +93,8 @@ node:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  ruleChain:
+    configmapName:
 
 jsexecutor:
   # kind can be either Deployment or StatefulSet


### PR DESCRIPTION
I manually generated yaml with and without configmap:

```
 helm template evp ./helm/thingsboard/ -s templates/node.yaml  --set node.ruleChain.configmapName="" > without.yaml 
```

```
 helm template evp ./helm/thingsboard/ -s templates/node.yaml  --set node.ruleChain.configmapName="some-config" > with.yaml 
```

```
$ diff without.yaml with.yaml 
97a98,100
>             - mountPath: /usr/share/thingsboard/data/json/tenant/rule_chains/root_rule_chain.json
>               subPath: root_rule_chain.json
>               name: some-config
120a124,129
>         - name: some-config
>           configMap:
>             name: some-config
>             items:
>             - key: rule_chain
>               path: root_rule_chain.json
```