### PR TITLE
EVP-2115 - Database upgrades can be skipped 

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -68,8 +68,7 @@ helm install --create-namespace -n thingsboard thingsboard thingsboard \
 * Upgrade database
 ```
 helm upgrade -n thingsboard thingsboard thingsboard \
-  --set initDBJob.operation=upgrade \
-  --set initDBJob.fromVersion=1.2.3
+  --set initDBJob.fromVersion="3.3.3"
 ```
 
 ## All options

--- a/helm/thingsboard/templates/initializedb-job.yaml
+++ b/helm/thingsboard/templates/initializedb-job.yaml
@@ -1,3 +1,4 @@
+{{- if or .Release.IsInstall .Values.initDBJob.fromVersion }}
 #
 # Copyright © 2016-2020 The Thingsboard Authors
 #
@@ -54,7 +55,11 @@ spec:
           - "-c"
           - "start-tb-node.sh"
         env:
-        - name: {{ .Values.initDBJob.operation | upper }}_TB
+        {{- if .Release.IsInstall }}
+        - name: INSTALL_TB
+        {{- else }}
+        - name: UPGRADE_TB        
+        {{- end }}
           value: "true"
         - name: LOAD_DEMO
           value: "{{ .Values.node.loadDemo }}"
@@ -73,3 +78,4 @@ spec:
               path: thingsboard.conf
             - key: logback
               path: logback.xml
+{{- end }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -261,12 +261,8 @@ cassandraInitDB:
     factor: 1
 
 initDBJob:
-  # set 'operation' to 'install' to create database
-  # and set to 'upgrade' to update the database to latest version
-  # starting at 'fromVersion' 
-  operation: "install"
-  # with the current version of the database for triggering the
-  # upgrade. 
+  # Set this value with current version of Thingsboard database if only if a database migration is needed.
+  # Database migration will be triggered starting at this version up to version currently installed by the helm command. 
   fromVersion: ""
 
 postgresInitDB:


### PR DESCRIPTION
 Relates to https://midokura.atlassian.net/browse/EVP-2115 and https://midokura.atlassian.net/browse/EVP-2027
 Database upgrades can be skipped if initDBJob.fromVersion parameter is not set. 

Notice that 'helm upgrade' command could be executed at any time without triggering any migration to the database.