### PR TITLE
[EVP-1800] Parametrize token expiration time.

### DIFF
--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -91,6 +91,10 @@ spec:
             value: "{{ .Release.Name }}-redis-master"
           - name: REDIS_PASSWORD
             value: "{{ .Values.redis.auth.password }}"
+          - name: JWT_TOKEN_EXPIRATION_TIME
+            value: {{ .Values.node.authorization.tokenExpirationTimeSeconds | default 9000 | quote }}
+          - name: JWT_REFRESH_TOKEN_EXPIRATION_TIME
+            value: {{ .Values.node.authorization.refreshTokenExpirationTimeSeconds | default 604800 | quote }}
           envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-node-db-config

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -95,6 +95,9 @@ node:
   affinity: {}
   ruleChain:
     configmapName:
+  authorization:
+    tokenExpirationTimeSeconds: "9000"
+    refreshTokenExpirationTimeSeconds: "604800"
 
 jsexecutor:
   # kind can be either Deployment or StatefulSet


### PR DESCRIPTION
So we can mitigate a possible bug in [TB rest client](https://github.com/thingsboard/thingsboard/issues/8038)

[JIRA](https://midokura.atlassian.net/browse/EVP-1800)

## Testing

Deployed evp2 using this TB helm chart as dependency, checked default values. Then set token expiration time to 2 seconds, restart evp-api pods and verified that Iot ping threads deadlocked after 5 token refreshes:

```
TP GET http://evp2-node:8080/api/dashboard/serverTime","context":"default"}
{"timestamp":"2023-02-06T20:53:25.002Z","level":"DEBUG","thread":"iot-ping-thread","logger":"org.springframework.web.client.RestTemplate","message":"Accept=[application/json, application/*+json]","context":"default"}
{"timestamp":"2023-02-06T20:53:25.009Z","level":"DEBUG","thread":"iot-ping-thread","logger":"org.springframework.web.client.RestTemplate","message":"HTTP POST http://evp2-node:8080/api/auth/token","context":"default"}
{"timestamp":"2023-02-06T20:53:25.010Z","level":"DEBUG","thread":"iot-ping-thread","logger":"org.springframework.web.client.RestTemplate","message":"Accept=[application/json, application/*+json]","context":"default"}
{"timestamp":"2023-02-06T20:53:25.010Z","level":"DEBUG","thread":"iot-ping-thread","logger":"org.springframework.web.client.RestTemplate","message":"Writing [{refreshToken=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJnb21pZG9nb0BtaWRva3VyYS5jb20iLCJzY29wZXMiOlsiUkVGUkVTSF9UT0tFTiJdLCJ1c2VySWQiOiI5MjE5YTc0MC1hNjJjLTExZWQtYmIyOS0yYmNhNGQ1MmMyZmUiLCJpc1B1YmxpYyI6ZmFsc2UsImlzcyI6InRoaW5nc2JvYXJkLmlvIiwianRpIjoiMGMwNWY2NDItNzY2Zi00MWI5LTg4ZjctMjY3MWU3M2Q4YmRiIiwiaWF0IjoxNjc1NzE2ODAzLCJleHAiOjE2NzYzMjE2MDN9.NNaf-9Ua5LuMBZqBpmWaXkbJr9laOcHKvUALFlFUrZthAIav24Rs6j_vOsEDFcymioB8G0sdrry3JFbgiIeYoQ}] with org.springframework.http.converter.json.MappingJackson2HttpMessageConverter","context":"default"}
```
