### PR TITLE
added: nodeSelector, tolerations and affinity to initDBJon

### DIFF
--- a/helm/thingsboard/templates/initializedb-job.yaml
+++ b/helm/thingsboard/templates/initializedb-job.yaml
@@ -78,4 +78,16 @@ spec:
               path: thingsboard.conf
             - key: logback
               path: logback.xml
+      {{- with .Values.initDBJob.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.initDBJob.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.initDBJob.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -267,6 +267,15 @@ initDBJob:
   # Set this value with current version of Thingsboard database if only if a database migration is needed.
   # Database migration will be triggered starting at this version up to version currently installed by the helm command. 
   fromVersion: ""
+  # Constrain Pods to nodes with specific labels
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  nodeSelector: {}
+  # Allow the scheduler to schedule pods with matching taints
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
+  # Expands the types of constraints you can define
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
 
 postgresInitDB:
   job:


### PR DESCRIPTION
## Description

Equal to: https://github.com/midokura/evp-chart/pull/235

The Job can't be scheduled on a multi-node K8s cluster because the user can't define the nodeSelector, affinity, and tolerations.