### PR TITLE
fix(node): Increase the available memory to TB node

### DIFF
--- a/helm/thingsboard/templates/node-configmap.yaml
+++ b/helm/thingsboard/templates/node-configmap.yaml
@@ -28,7 +28,7 @@ data:
       export JAVA_OPTS="$JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/thingsboard/${TB_SERVICE_ID}-heapdump.bin"
       export JAVA_OPTS="$JAVA_OPTS -XX:-UseBiasedLocking -XX:+UseTLAB -XX:+ResizeTLAB -XX:+PerfDisableSharedMem -XX:+UseCondCardMark"
       export JAVA_OPTS="$JAVA_OPTS -XX:+UseG1GC -XX:MaxGCPauseMillis=500 -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:MaxTenuringThreshold=10"
-      export JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+      export JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError -XX:+UseContainerSupport -XX:MaxRAMPercentage=80"
       export LOG_FILENAME=thingsboard.out
       export LOADER_PATH=/usr/share/thingsboard/conf,/usr/share/thingsboard/extensions
   logback: |

--- a/helm/thingsboard/templates/transport-configmap.yaml
+++ b/helm/thingsboard/templates/transport-configmap.yaml
@@ -32,7 +32,7 @@ data:
       export JAVA_OPTS="$JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/tb-{{ . }}-transport/${TB_SERVICE_ID}-heapdump.bin"
       export JAVA_OPTS="$JAVA_OPTS -XX:-UseBiasedLocking -XX:+UseTLAB -XX:+ResizeTLAB -XX:+PerfDisableSharedMem -XX:+UseCondCardMark"
       export JAVA_OPTS="$JAVA_OPTS -XX:+UseG1GC -XX:MaxGCPauseMillis=500 -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:MaxTenuringThreshold=10"
-      export JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+      export JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError -XX:+UseContainerSupport -XX:MaxRAMPercentage=80"
       export LOG_FILENAME=tb-{{ . }}-transport.out
       export LOADER_PATH=/usr/share/tb-{{ . }}-transport/conf
   logback: |


### PR DESCRIPTION
`UseContainerSupport` is set to allow the JVM to be aware of the container resource limits. This should be enabled by default, but was added for visibility.
`MaxRAMPercentage` overrides the default used, which should be 75%, but in the EVP2 perf cluster it was only 25%, so that we allow TB node to handle more devices (>1000).