### PR TITLE
feat(init): updating to tb 3.5.1

### DIFF
--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -56,7 +56,7 @@ spec:
         - name: check-db-queue-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'export PGPASSWORD=''{{ index .Values "postgresql-ha" "postgresql" "password" }}'' && export row_count=0 && until [ $row_count -eq 3 ]; do sleep 1; row_count=$(psql -h evp-tb-pgpool -U postgres -d thingsboard --set=on_error_stop=1 -t -c "SELECT count(*) FROM queue;"); done;']
+            'export PGPASSWORD=''{{ index .Values "postgresql-ha" "postgresql" "password" }}'' && export row_count=0 && until [ $row_count -eq 3 ]; do sleep 1; row_count=$(psql -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -U {{ index .Values "postgresql-ha" "postgresql" "username" }} -d {{ index .Values "postgresql-ha" "postgresql" "database" }} --set=on_error_stop=1 -t -c "SELECT count(*) FROM queue;"); done;']
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -53,6 +53,10 @@ spec:
           command: ['sh', '-c',
             'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
             do echo waiting for database; sleep 2; done;']
+        - name: check-db-queue-ready
+          image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
+          command: ['sh', '-c',
+            'export PGPASSWORD=''{{ index .Values "postgresql-ha" "postgresql" "password" }}'' && export row_count=0 && until [ $row_count -eq 3 ]; do sleep 1; row_count=$(psql -h evp-tb-pgpool -U postgres -d thingsboard --set=on_error_stop=1 -t -c "SELECT count(*) FROM queue;"); done;']
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -56,7 +56,7 @@ spec:
         - name: check-db-queue-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'export PGPASSWORD=''{{ index .Values "postgresql-ha" "postgresql" "password" }}'' && export row_count=0 && until [ $row_count -eq 3 ]; do sleep 1; row_count=$(psql -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -U {{ index .Values "postgresql-ha" "postgresql" "username" }} -d {{ index .Values "postgresql-ha" "postgresql" "database" }} --set=on_error_stop=1 -t -c "SELECT count(*) FROM queue;"); done;']
+            'export PGPASSWORD=''{{ index .Values "postgresql-ha" "postgresql" "password" }}'' && export row_count=0 && until [ $row_count -ge 3 ]; do sleep 1; row_count=$(psql -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -U {{ index .Values "postgresql-ha" "postgresql" "username" }} -d {{ index .Values "postgresql-ha" "postgresql" "database" }} --set=on_error_stop=1 -t -c "SELECT count(*) FROM queue;"); done;']
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -17,7 +17,7 @@
 global:
   image:
     server: docker.io
-    tag: "3.5.0"
+    tag: "3.5.1"
     pullSecrets: []
     pullPolicy: Always
   jsonLogs: false

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -17,7 +17,7 @@
 global:
   image:
     server: docker.io
-    tag: "3.4.1"
+    tag: "3.5.0"
     pullSecrets: []
     pullPolicy: Always
   jsonLogs: false


### PR DESCRIPTION
We have to add an initContainer command to check if the queue table has the correct values, if not, there is a race condition where evp-node starts before the init-db job has finished, so the queues are not loaded and the evp-node fails constantly.

We think this is the reason why the evp ci was failing when we updated to 3.5.0

Test:

This repository doesn't have tests, so, for the moment, we had to test this change manually. What we did is deploy thingsboard 3.5.0 with the change in the initcontainer, the check worked as expected, the rows were in the database. Then we deleted the rows and restart tb-node, it didn't start. 

This check is far from ideal, but it is one of the many problems with TB. Please, if you have any other suggestion, let us know :)