### PR TITLE
fix(partition): set the service id as the pod id

### DIFF
--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -70,7 +70,10 @@ spec:
             name: rpc
           env:
           - name: TB_SERVICE_ID
-            value: "tb-node"
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
           - name: TB_SERVICE_TYPE
             value: "monolith"
           {{- if eq .Values.monitoring.enabled true }}


### PR DESCRIPTION
When a tb node starts it register to zookeeper with a service info that contains this TB_SERVICE_ID. When all the pods have the same id, they all share the same partitions, leaving the rest to no one.