### PR TITLE
fix(cd): generate unique name for db init job and pod

### DIFF
--- a/helm/thingsboard/templates/initializedb-job.yaml
+++ b/helm/thingsboard/templates/initializedb-job.yaml
@@ -18,7 +18,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: '{{ .Release.Name }}-init-tb-db'
+  name: '{{ .Release.Name }}-init-tb-db-{{ .Release.Revision }}'
   labels:
     {{- include "thingsboard.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Jobs specs are immutable and so when upgrading the helm chart of demo environment it may fail complaining that we are trying to upgrade an immutable job. This change should make the deployment of new helm releases more reliable.