### PR TITLE
fixed(metrics): prometheus scrapping pod port

### DIFF
--- a/helm/thingsboard/templates/component-service.yaml
+++ b/helm/thingsboard/templates/component-service.yaml
@@ -44,12 +44,6 @@ spec:
       protocol: {{ $componentValues.port.protocol }}
       name: {{ $componentValues.port.name }}-{{ . }}
     {{- end -}}
-    {{- if $componentValues.http }}
-    - port: {{ $componentValues.service.http.port }}
-      targetPort: {{ $componentValues.http.port.name }}
-      protocol: {{ $componentValues.http.port.protocol }}
-      name: {{ $componentValues.http.port.name }}
-    {{- end  }}
   selector:
     app.kubernetes.io/instance: {{ $releaseName}}-{{ $component }}
     app.kubernetes.io/name: thingsboard-{{ $component }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -155,14 +155,12 @@ mqtt:
   timeout: 10000
   podAnnotations:
     "prometheus.io/path": "/actuator/prometheus"
-    "prometheus.io/port": "8884"
+    "prometheus.io/port": "8082"
     "prometheus.io/scrape": "true"
   podSecurityContext: {}
   securityContext: {}
   service:
     type: ClusterIP
-    http:
-      port: 8884
     port: 8883
     additionalPorts: []
   resources: {}


### PR DESCRIPTION
We were enabling port at service level and we really need the metrics from each pod