### PR TITLE
chore(db): add ts_latest and state to Cassandra

### DIFF
--- a/helm/thingsboard/templates/node-db-configmap.yaml
+++ b/helm/thingsboard/templates/node-db-configmap.yaml
@@ -24,12 +24,16 @@ metadata:
 data:
 {{- if .Values.cassandra.enabled }}
   DATABASE_TS_TYPE: cassandra
+  DATABASE_TS_LATEST_TYPE: cassandra
+  PERSIST_STATE_TO_TELEMETRY: 'true'
   CASSANDRA_URL: {{ .Release.Name }}-cassandra:9042
   CASSANDRA_USE_CREDENTIALS: 'true'
   CASSANDRA_USERNAME: {{ .Values.cassandra.dbUser.user }}
   CASSANDRA_PASSWORD: {{ .Values.cassandra.dbUser.password }}
+  PERSIST_STATE_TO_TELEMETRY: 'true'
 {{ else }}
   DATABASE_TS_TYPE: sql
+  DATABASE_TS_LATEST_TYPE: sql
 {{- end }}
   SPRING_JPA_DATABASE_PLATFORM: org.hibernate.dialect.PostgreSQLDialect
   SPRING_DRIVER_CLASS_NAME: org.postgresql.Driver
@@ -42,3 +46,4 @@ data:
   SPRING_DATASOURCE_USERNAME: {{ .Values.postgresqlExternal.username }}
   SPRING_DATASOURCE_PASSWORD: {{ .Values.postgresqlExternal.password }}
   {{ end }}
+

--- a/helm/thingsboard/templates/node-db-configmap.yaml
+++ b/helm/thingsboard/templates/node-db-configmap.yaml
@@ -30,7 +30,6 @@ data:
   CASSANDRA_USE_CREDENTIALS: 'true'
   CASSANDRA_USERNAME: {{ .Values.cassandra.dbUser.user }}
   CASSANDRA_PASSWORD: {{ .Values.cassandra.dbUser.password }}
-  PERSIST_STATE_TO_TELEMETRY: 'true'
 {{ else }}
   DATABASE_TS_TYPE: sql
   DATABASE_TS_LATEST_TYPE: sql


### PR DESCRIPTION
when doing performance tests, we notice an increase in performance if the ts_latest and state goes to cassandra instead of going to postgresql.

**Before** adding these config we had a large queue of sql entities to save.
![image](https://github.com/midokura/thingsboard-ce-k8s/assets/97443651/db22dd05-9a7e-425f-acca-ad4e57fdb97f)
And this is the pod memory usage, I only put the old gen because is the one that gets filled up quickest:
![image](https://github.com/midokura/thingsboard-ce-k8s/assets/97443651/1db15b78-3d69-4897-906b-b2942cecf0ef)


**After** adding these configs the queue has been reduced (there are no values for ts latest):
![image](https://github.com/midokura/thingsboard-ce-k8s/assets/97443651/7f246175-a48a-4ab6-b1df-9b0715419185)
And this is the pod memory usage:
![image](https://github.com/midokura/thingsboard-ce-k8s/assets/97443651/367c6499-fd66-4208-9f75-943f4d68d129)

