### PR TITLE
fix(mqtt): put a dynamic service id

### DIFF
--- a/helm/thingsboard/templates/mqtt-transport.yaml
+++ b/helm/thingsboard/templates/mqtt-transport.yaml
@@ -60,7 +60,10 @@ spec:
             name: {{ .Values.mqtt.http.port.name }}
           env:
           - name: TB_SERVICE_ID
-            value: "tb-mqtt-transport"
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
           - name: TB_QUEUE_TYPE
             value: "kafka"
           - name: MQTT_TIMEOUT


### PR DESCRIPTION
An mqtt pod communicates with a tb node based on a topic with suffix it's serviceId. It needs to be unique between all mqtt pods so that each one only receives the responses that are for them. For example, one of the use cases is validating a device certificate, we were seeing a lot of invalid certificate errors because the other pod was receiving the response.