### PR TITLE
chore(sql): add thread count sql batch configuration

### DIFF
--- a/helm/thingsboard/templates/node-db-configmap.yaml
+++ b/helm/thingsboard/templates/node-db-configmap.yaml
@@ -45,4 +45,8 @@ data:
   SPRING_DATASOURCE_USERNAME: {{ .Values.postgresqlExternal.username }}
   SPRING_DATASOURCE_PASSWORD: {{ .Values.postgresqlExternal.password }}
   {{ end }}
+  SQL_ATTRIBUTES_BATCH_THREADS: {{ .Values.sql.attributes.batch.threads | quote }}
+  SQL_EVENTS_BATCH_THREADS: {{ .Values.sql.events.batch.threads | quote }}
+  SQL_TS_BATCH_THREADS: {{ .Values.sql.ts.batch.threads | quote }}
+  SQL_TS_LATEST_BATCH_THREADS: {{ .Values.sql.ts-latest.batch.threads | quote }}
 

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -369,3 +369,17 @@ kafka:
     persistence:
       enabled: false
 
+sql:
+  attributes:
+    batch:
+      threads: 30
+  events:
+    batch:
+      threads: 10
+  ts:
+    batch:
+      threads: 10
+  ts-latest:
+    batch:
+      threads: 10
+


### PR DESCRIPTION
While doing performance tests, it was noticeable in performance the increase of sql batch threads, and we want to be able to modify them from the values.

This is the write delay with the default configuration ([link](https://github.com/thingsboard/thingsboard/blob/7dcebed62426513b3f7eeebe0a2267c4dbc6648d/application/src/main/resources/thingsboard.yml#L259))
![image](https://github.com/midokura/thingsboard-ce-k8s/assets/97443651/3fda739c-395b-4b3b-b725-47888f650d7e)

We have done many changes, but the result now is this:
![image](https://github.com/midokura/thingsboard-ce-k8s/assets/97443651/6d5c9fd6-c69c-4a56-bef9-70d16a746491)

