### PR TITLE
chore(ts): allow to enable timescale for timeseries

### DIFF
--- a/helm/thingsboard/templates/node-db-configmap.yaml
+++ b/helm/thingsboard/templates/node-db-configmap.yaml
@@ -30,6 +30,9 @@ data:
   CASSANDRA_USE_CREDENTIALS: 'true'
   CASSANDRA_USERNAME: {{ .Values.cassandra.dbUser.user }}
   CASSANDRA_PASSWORD: {{ .Values.cassandra.dbUser.password }}
+{{- else if .Values.timescale.enabled }}
+  DATABASE_TS_TYPE: timescale
+  DATABASE_TS_LATEST_TYPE: timescale
 {{ else }}
   DATABASE_TS_TYPE: sql
   DATABASE_TS_LATEST_TYPE: sql

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -302,6 +302,9 @@ postgresInitDB:
       # default value of the timeout for the pg_isready command
       timeout: 3
 
+timescale:
+  enabled: false
+
 cassandra:
   # Database can be either postgres or hybrid (entities in postgres and timeseries in cassandra)
   # for an postgresql database set cassandra.enabled as false


### PR DESCRIPTION
We want to enable/disable easily timescale/cassandra for timeseries to benchmark it