### PR TITLE
chore(helm): add extra db environment variables

### DIFF
--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -110,6 +110,10 @@ spec:
             value: {{ .Values.node.authorization.tokenExpirationTimeSeconds | default 9000 | quote }}
           - name: JWT_REFRESH_TOKEN_EXPIRATION_TIME
             value: {{ .Values.node.authorization.refreshTokenExpirationTimeSeconds | default 604800 | quote }}
+          {{- range .Values.node.extraEnvVars }}
+          - name: {{ .key }}
+            value: {{ .value | quote }}
+          {{- end }}
           envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-node-db-config

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -105,6 +105,13 @@ node:
   authorization:
     tokenExpirationTimeSeconds: "9000"
     refreshTokenExpirationTimeSeconds: "604800"
+  extraEnvVars:
+  - key: SQL_TTL_TS_ENABLED
+    value: "true"
+  - key: SQL_TTL_TS_EXECUTION_INTERVAL
+    value: "3600000"
+  - key: SQL_TTL_TS_TS_KEY_VALUE_TTL
+    value: "7200"
 
 jsexecutor:
   # kind can be either Deployment or StatefulSet

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -105,13 +105,6 @@ node:
   authorization:
     tokenExpirationTimeSeconds: "9000"
     refreshTokenExpirationTimeSeconds: "604800"
-  extraEnvVars:
-  - key: SQL_TTL_TS_ENABLED
-    value: "true"
-  - key: SQL_TTL_TS_EXECUTION_INTERVAL
-    value: "3600000"
-  - key: SQL_TTL_TS_TS_KEY_VALUE_TTL
-    value: "7200"
 
 jsexecutor:
   # kind can be either Deployment or StatefulSet


### PR DESCRIPTION
While doing performance test, we are constantly configuring the environment variables of thingsboard, but if we want to make it permanent in flux, we need to generate a new version of thingsboard-ce, which delays the development. This way, we can alter the Values in flux and add new env variables.

If I add the next in the values:
```
  extraEnvVars:
  - key: SQL_TTL_TS_ENABLED
    value: "true"
  - key: SQL_TTL_TS_EXECUTION_INTERVAL
    value: "3600000"
  - key: SQL_TTL_TS_TS_KEY_VALUE_TTL
    value: "7200"
```

I get the next in the node statefulset:
```
- name: SQL_TTL_TS_ENABLED
  value: "true"
- name: SQL_TTL_TS_EXECUTION_INTERVAL
  value: "3600000"
- name: SQL_TTL_TS_TS_KEY_VALUE_TTL
  value: "7200"
```