### PR TITLE
feat(mqtt): enable allowlisting for mqtt endpoint

### DIFF
--- a/helm/thingsboard/templates/component-service.yaml
+++ b/helm/thingsboard/templates/component-service.yaml
@@ -33,6 +33,10 @@ metadata:
   {{- end }}
 spec:
   type: {{ $componentValues.service.type }}
+{{- with $componentValues.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   ports:
     - port: {{ $componentValues.service.port }}
       targetPort: {{ $componentValues.port.name }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -163,6 +163,7 @@ mqtt:
     type: ClusterIP
     port: 8883
     additionalPorts: []
+    loadBalancerSourceRanges: []
   resources: {}
   autoscaling:
     enabled: false

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -163,6 +163,11 @@ mqtt:
     type: ClusterIP
     port: 8883
     additionalPorts: []
+    # Allow list of IPs that can access the load balancer where this service is attached to.
+    # By default, an empty list blocks all traffic. Example:
+    # loadBalancerSourceRanges:
+    # - 1.1.1.1/32
+    # - 2.2.2.2/32
     loadBalancerSourceRanges: []
   resources: {}
   autoscaling:


### PR DESCRIPTION
The MQTT endpoint is exposed via a service object attached to a
load balancer in the cloud provider. If we want to allowlist this
service we need to specify the ranges using the
`loadBalancerSourceRanges` property of the Service. For AKS, this
is documented [here].

[here]: https://learn.microsoft.com/en-us/azure/aks/load-balancer-standard#restrict-inbound-traffic-to-specific-ip-ranges

EVP-2746
<details>
<summary>
Committer details
</summary>
Local-Branch: master
</details>