### PR TITLE
fix(tb-node): Increase timeout for readiness probe.

### DIFF
--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -131,6 +131,8 @@ spec:
             httpGet:
               path: /login
               port: http
+            initialDelaySeconds: 15
+            timeoutSeconds: 10
           livenessProbe:
             httpGet:
               path: /login


### PR DESCRIPTION
JIRA: https://midokura.atlassian.net/browse/EVP-2756

The issue in my local deployment:

```
NAME                                              READY   STATUS    RESTARTS        AGE
evp-api-84c65c4c5-9rfn4                           1/1     Running   1 (2m20s ago)   5m54s
evp-env-cert-manager-5d5949cf8b-zzxpm             1/1     Running   0               27m
evp-env-cert-manager-cainjector-656b55895-qt7ws   1/1     Running   0               27m
evp-env-cert-manager-webhook-c5ff45ff6-m22sb      1/1     Running   0               27m
evp-env-controller-5965f74989-lgsjc               1/1     Running   0               27m
evp-init-tb-db-3-dfn8g                            1/1     Running   0               4m49s
evp-jsexecutor-db6b957bc-bncsw                    1/1     Running   0               24m
evp-kafka-0                                       1/1     Running   0               24m
evp-mqtt-transport-0                              1/1     Running   0               24m
evp-node-0                                        0/1     Running   1 (2m4s ago)    24m
evp-pgpool-74fd9b7ff7-8n6l8                       1/1     Running   0               24m
evp-postgresql-0                                  1/1     Running   0               24m
evp-redis-master-649dd8b5d8-2lfxv                 1/1     Running   0               24m
evp-tb-pgpool-ffd7f88f7-h9th9                     1/1     Running   0               24m
evp-tb-postgresql-0                               1/1     Running   0               24m
evp-web-ui-68f764bbf-ndcvs                        1/1     Running   0               24m
evp-zookeeper-0                                   1/1     Running   0               24m
metallb-controller-7567fb574-wg2hp                1/1     Running   0               28m
metallb-speaker-58wd2                             1/1     Running   1 (2m37s ago)   28m
storage-azurite-deployment-85776bbdc9-cm45v       1/1     Running   0               26m
```