### PR TITLE
chore(postgres): bump to postgresql-ha 11.8.1

### DIFF
--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -24,7 +24,7 @@ icon: https://avatars.githubusercontent.com/u/24291394?s=200&v=4
 home: https://github.com/thingsboard/thingsboard-ce-k8s/
 dependencies:
   - name: postgresql-ha
-    version: 8.5.2
+    version: 11.8.1
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql-ha.enabled
   - name: cassandra


### PR DESCRIPTION
We have found an issue with the current version of postgres that is fixed with newest versions of it.