### PR TITLE
fix(helm): fix postgres fields

### DIFF
--- a/helm/thingsboard/templates/initializedb-job.yaml
+++ b/helm/thingsboard/templates/initializedb-job.yaml
@@ -32,7 +32,7 @@ spec:
         - name: check-postgres-db-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
+            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
             do echo waiting for database; sleep 2; done;']
         {{- end  }}
       containers:

--- a/helm/thingsboard/templates/js-executor.yaml
+++ b/helm/thingsboard/templates/js-executor.yaml
@@ -52,7 +52,7 @@ spec:
         - name: check-db-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
+            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
             do echo waiting for database; sleep 2; done;']
         {{- end  }}
       containers:

--- a/helm/thingsboard/templates/node-db-configmap.yaml
+++ b/helm/thingsboard/templates/node-db-configmap.yaml
@@ -40,7 +40,7 @@ data:
   SPRING_JPA_DATABASE_PLATFORM: org.hibernate.dialect.PostgreSQLDialect
   SPRING_DRIVER_CLASS_NAME: org.postgresql.Driver
   {{ if index .Values "postgresql-ha" "enabled" }}
-  SPRING_DATASOURCE_URL: jdbc:postgresql://{{ include "thingsboard.pgpoolservicename" . }}:{{ index .Values "postgresql-ha" "pgpool" "containerPort" }}/{{ index .Values "postgresql-ha" "postgresql" "database" }}
+  SPRING_DATASOURCE_URL: jdbc:postgresql://{{ include "thingsboard.pgpoolservicename" . }}:{{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }}/{{ index .Values "postgresql-ha" "postgresql" "database" }}
   SPRING_DATASOURCE_USERNAME: {{ index .Values "postgresql-ha" "postgresql" "username" }}
   SPRING_DATASOURCE_PASSWORD: {{ index .Values "postgresql-ha" "postgresql" "password" }}
   {{ else }}

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -52,12 +52,12 @@ spec:
         - name: check-db-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
+            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
             do echo waiting for database; sleep 2; done;']
         - name: check-db-queue-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'export PGPASSWORD=''{{ index .Values "postgresql-ha" "postgresql" "password" }}'' && export row_count=0 && until [ $row_count -ge 3 ]; do sleep 1; row_count=$(psql -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -U {{ index .Values "postgresql-ha" "postgresql" "username" }} -d {{ index .Values "postgresql-ha" "postgresql" "database" }} --set=on_error_stop=1 -t -c "SELECT count(*) FROM queue;"); done;']
+            'export PGPASSWORD=''{{ index .Values "postgresql-ha" "postgresql" "password" }}'' && export row_count=0 && until [ $row_count -ge 3 ]; do sleep 1; row_count=$(psql -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }} -U {{ index .Values "postgresql-ha" "postgresql" "username" }} -d {{ index .Values "postgresql-ha" "postgresql" "database" }} --set=on_error_stop=1 -t -c "SELECT count(*) FROM queue;"); done;']
         {{- end  }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -347,13 +347,11 @@ postgresql-ha:
     password: setplease
     repmgrPassword: setplease
   postgresqlImage:
-    tag: 12
+    tag: 15.3
   pgpool:
     adminPassword: setplease
     replicaCount: 1
     useLoadBalancing: false
-  pgpoolImage:
-    tag: 4.3.3
 
 redis:
   # Set architecture to either standalone or replication


### PR DESCRIPTION
new version of postgres doesn't have the same fields.

Tested locally:
```
(⎈|kind-kind:default)
$ salmendros@salmendros [12:30:42] [~/midokura/dev/python_projects/evp-dev-tools/evp-cli] [main *]
-> % k get po
NAME                                              READY   STATUS    RESTARTS        AGE
evp-api-5f9dfd489c-52c97                          1/1     Running   0               13m
evp-env-cert-manager-5d5949cf8b-lslq9             1/1     Running   0               15m
evp-env-cert-manager-cainjector-656b55895-grfc2   1/1     Running   0               15m
evp-env-cert-manager-webhook-c5ff45ff6-6qf9h      1/1     Running   0               15m
evp-env-controller-5965f74989-hzzqt               1/1     Running   0               15m
evp-jsexecutor-6fd7f4c745-jkbr8                   1/1     Running   0               13m
evp-kafka-0                                       1/1     Running   5 (9m30s ago)   13m
evp-mqtt-transport-0                              1/1     Running   0               13m
evp-node-0                                        1/1     Running   0               13m
evp-pgpool-865d668657-5xrr6                       1/1     Running   3 (7m59s ago)   13m
evp-postgresql-0                                  1/1     Running   0               13m
evp-redis-master-6d6d6968b6-wpm6g                 1/1     Running   0               13m
evp-tb-pgpool-68cb8fff45-jcffd                    1/1     Running   2 (9m9s ago)    13m
evp-tb-postgresql-0                               1/1     Running   0               13m
evp-web-ui-68f764bbf-mlvnf                        1/1     Running   0               13m
evp-zookeeper-0                                   1/1     Running   0               13m
metallb-controller-54f6fbcd4b-26m8k               1/1     Running   0               17m
metallb-speaker-dvhh5                             1/1     Running   0               16m
storage-azurite-deployment-85776bbdc9-m55gt       1/1     Running   0               14m
```
