### PR TITLE
revert: bump to postgresql-ha 11.8.1

### DIFF
--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -24,7 +24,7 @@ icon: https://avatars.githubusercontent.com/u/24291394?s=200&v=4
 home: https://github.com/thingsboard/thingsboard-ce-k8s/
 dependencies:
   - name: postgresql-ha
-    version: 11.8.1
+    version: 8.5.2
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql-ha.enabled
   - name: cassandra

--- a/helm/thingsboard/templates/initializedb-job.yaml
+++ b/helm/thingsboard/templates/initializedb-job.yaml
@@ -32,7 +32,7 @@ spec:
         - name: check-postgres-db-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
+            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
             do echo waiting for database; sleep 2; done;']
         {{- end  }}
       containers:

--- a/helm/thingsboard/templates/js-executor.yaml
+++ b/helm/thingsboard/templates/js-executor.yaml
@@ -52,7 +52,7 @@ spec:
         - name: check-db-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
+            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
             do echo waiting for database; sleep 2; done;']
         {{- end  }}
       containers:

--- a/helm/thingsboard/templates/node-db-configmap.yaml
+++ b/helm/thingsboard/templates/node-db-configmap.yaml
@@ -40,7 +40,7 @@ data:
   SPRING_JPA_DATABASE_PLATFORM: org.hibernate.dialect.PostgreSQLDialect
   SPRING_DRIVER_CLASS_NAME: org.postgresql.Driver
   {{ if index .Values "postgresql-ha" "enabled" }}
-  SPRING_DATASOURCE_URL: jdbc:postgresql://{{ include "thingsboard.pgpoolservicename" . }}:{{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }}/{{ index .Values "postgresql-ha" "postgresql" "database" }}
+  SPRING_DATASOURCE_URL: jdbc:postgresql://{{ include "thingsboard.pgpoolservicename" . }}:{{ index .Values "postgresql-ha" "pgpool" "containerPort" }}/{{ index .Values "postgresql-ha" "postgresql" "database" }}
   SPRING_DATASOURCE_USERNAME: {{ index .Values "postgresql-ha" "postgresql" "username" }}
   SPRING_DATASOURCE_PASSWORD: {{ index .Values "postgresql-ha" "postgresql" "password" }}
   {{ else }}

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -52,12 +52,12 @@ spec:
         - name: check-db-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
+            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -t {{ .Values.postgresInitDB.job.check.timeout }};
             do echo waiting for database; sleep 2; done;']
         - name: check-db-queue-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'export PGPASSWORD=''{{ index .Values "postgresql-ha" "postgresql" "password" }}'' && export row_count=0 && until [ $row_count -ge 3 ]; do sleep 1; row_count=$(psql -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }} -U {{ index .Values "postgresql-ha" "postgresql" "username" }} -d {{ index .Values "postgresql-ha" "postgresql" "database" }} --set=on_error_stop=1 -t -c "SELECT count(*) FROM queue;"); done;']
+            'export PGPASSWORD=''{{ index .Values "postgresql-ha" "postgresql" "password" }}'' && export row_count=0 && until [ $row_count -ge 3 ]; do sleep 1; row_count=$(psql -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -U {{ index .Values "postgresql-ha" "postgresql" "username" }} -d {{ index .Values "postgresql-ha" "postgresql" "database" }} --set=on_error_stop=1 -t -c "SELECT count(*) FROM queue;"); done;']
         {{- end  }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -347,11 +347,13 @@ postgresql-ha:
     password: setplease
     repmgrPassword: setplease
   postgresqlImage:
-    tag: 15.3
+    tag: 12
   pgpool:
     adminPassword: setplease
     replicaCount: 1
     useLoadBalancing: false
+  pgpoolImage:
+    tag: 4.3.3
 
 redis:
   # Set architecture to either standalone or replication


### PR DESCRIPTION
This reverts commits 75cf58a1ea0a0afe88a98aa7228757eec428f6b5 and 76fbb3ed0f63e44d35437bb38447f5607700e56d.

Upgrading the `postgresql-ha` HELM chart fails in demo and performance environments, due to the changes to the statefulset that requires it to be recreated.

Error example from installing the `evp` HELM chart:
```
Upgrade "evp" failed: cannot patch "evp-postgresql" with kind StatefulSet: StatefulSet.apps "evp-postgresql" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden && cannot patch "evp-tb-postgresql" with kind StatefulSet: StatefulSet.apps "evp-tb-postgresql" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
```