### PR TITLE
Align default inactivity timeout with EVP configuration

### DIFF
--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -114,6 +114,8 @@ spec:
           - name: {{ .key }}
             value: {{ .value | quote }}
           {{- end }}
+          - name: DEFAULT_INACTIVITY_TIMEOUT
+            value: {{ .Values.node.state.defaultInactivityTimeoutInSec | default 60 | quote }}
           envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-node-db-config

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -80,6 +80,8 @@ node:
   service:
     type: ClusterIP
     port: 8080
+  state:
+    defaultInactivityTimeoutInSec: "60"
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
EVP1 was not setting per device inactivity timeout (so it was using a default of 10 minutes). In EVP2 though, we use a per device inactivity timeout of 1 minute.

To avoid having to deal with per device inactivity timeout during migration from EVP1 to EVP2, we set a global default of 1 minute so if we don't set the per device inactivity, we'll default to the right timeout.

References:
[code](https://github.com/thingsboard/thingsboard/blob/e4bf5a9b3a5134c20df3c014da170cbf9fa687c2/application/src/main/resources/thingsboard.yml#L660) [docs](https://thingsboard.io/docs/user-guide/device-connectivity-status/)