### PR TITLE
chore(helm): add mqtt extra env variables

### DIFF
--- a/helm/thingsboard/templates/mqtt-transport.yaml
+++ b/helm/thingsboard/templates/mqtt-transport.yaml
@@ -104,7 +104,7 @@ spec:
             value: "{{ .Values.mqtt.port.number }}"
           {{- end }}
           {{- range .Values.mqtt.extraEnvVars }}
-          - name: {{ .key }}
+          - name: {{ .key | upper  }}
             value: {{ .value | quote }}
           {{- end }}
           volumeMounts:

--- a/helm/thingsboard/templates/mqtt-transport.yaml
+++ b/helm/thingsboard/templates/mqtt-transport.yaml
@@ -103,6 +103,10 @@ spec:
           - name: MQTT_BIND_PORT
             value: "{{ .Values.mqtt.port.number }}"
           {{- end }}
+          {{- range .Values.mqtt.extraEnvVars }}
+          - name: {{ .key }}
+            value: {{ .value | quote }}
+          {{- end }}
           volumeMounts:
             - mountPath: /config
               name: {{ .Release.Name }}-mqtt-transport-config

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -111,7 +111,7 @@ spec:
           - name: JWT_REFRESH_TOKEN_EXPIRATION_TIME
             value: {{ .Values.node.authorization.refreshTokenExpirationTimeSeconds | default 604800 | quote }}
           {{- range .Values.node.extraEnvVars }}
-          - name: {{ .key }}
+          - name: {{ .key | upper }}
             value: {{ .value | quote }}
           {{- end }}
           - name: DEFAULT_INACTIVITY_TIMEOUT


### PR DESCRIPTION
While doing performance tests we often find ourselves modifying TB configuration environment variables and having to create PR's to add the possibility to configure them. With this way, we have more flexibility to configure TB.