### PR TITLE
feature(timescale): Add more threads to write to Timescale

### DIFF
--- a/helm/thingsboard/templates/node-db-configmap.yaml
+++ b/helm/thingsboard/templates/node-db-configmap.yaml
@@ -52,6 +52,7 @@ data:
   SQL_EVENTS_BATCH_THREADS: {{ .Values.sql.events.batch.threads | quote }}
   SQL_TS_BATCH_THREADS: {{ .Values.sql.ts.batch.threads | quote }}
   SQL_TS_LATEST_BATCH_THREADS: {{ index .Values.sql "ts-latest" "batch" "threads" | quote }}
+  SQL_TIMESCALE_BATCH_THREADS: {{ .Values.sql.timescale.batch.threads | quote }}
   QUEUE_RULEENGINE_PROMETHEUSSTATS_ENABLED: {{ index .Values "rule-engine" "prometheus-stats" "enabled" | quote }}
   TB_QUEUE_RE_MAIN_PROCESSING_STRATEGY_TYPE: {{ index .Values "rule-engine" "queues" "main" "processing-strategy-type" | quote }}
 

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -393,6 +393,9 @@ sql:
   ts-latest:
     batch:
       threads: 10
+  timescale:
+    batch:
+      threads: 10
 
 rule-engine:
   prometheus-stats:


### PR DESCRIPTION
While testing the performance of Thingsboard writing telemetries to TimescaleDB, we noticed that supporting 4000 or more devices with only the default (3) number of threads is not possible.

Futher testing with 10 threads allowed us to scale to 4500 devices (for 5000, the latency is just a few seconds above the threshold, instead of minutes.)