### PR TITLE
feat(inactivity): set 600 seconds by default

### DIFF
--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -115,7 +115,7 @@ spec:
             value: {{ .value | quote }}
           {{- end }}
           - name: DEFAULT_INACTIVITY_TIMEOUT
-            value: {{ .Values.node.state.defaultInactivityTimeoutInSec | default 60 | quote }}
+            value: {{ .Values.node.state.defaultInactivityTimeoutInSec | default 600 | quote }}
           envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-node-db-config

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -81,7 +81,7 @@ node:
     type: ClusterIP
     port: 8080
   state:
-    defaultInactivityTimeoutInSec: "60"
+    defaultInactivityTimeoutInSec: "600"
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
so we follow the thingsboard default and what SSS is requesting to be
set by default.
<details>
<summary>
Committer details
</summary>
Local-Branch: increaseto10mins
</details>