### PR TITLE
feat(mqtt): support explicit service nodePort

### DIFF
--- a/helm/thingsboard/templates/component-service.yaml
+++ b/helm/thingsboard/templates/component-service.yaml
@@ -46,6 +46,9 @@ spec:
   ports:
     - port: {{ $componentValues.service.port }}
       targetPort: {{ $componentValues.port.name }}
+      {{- if $componentValues.service.nodePort }}
+      nodePort: {{ $componentValues.service.nodePort }}
+      {{- end }}
       protocol: {{ $componentValues.port.protocol }}
       name: {{ $componentValues.port.name }}
     {{- range $componentValues.service.additionalPorts }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -165,6 +165,8 @@ mqtt:
     ipv6: false
     type: ClusterIP
     port: 8883
+    # ClusterIP service assings random nodePort when created, can be set to desired value here
+    # nodePort: 30883
     additionalPorts: []
     # Allow list of IPs that can access the load balancer where this service is attached to.
     # By default, an empty list blocks all traffic. Example:


### PR DESCRIPTION
By default & by design, ClusteIP k8s Service does set nodePort in the Service object spec when created, to a random value within some cluster-specific range. This change allows specifiying an explicit nodePort value.

The feature is disabled by default.

See [related PR](https://github.com/midokura/evp-dev-tools/pull/480#discussion_r1351684571) for more details why this is needed.