### PR TITLE
fix(helm): Fix appVersion to 3.5.1

### DIFF
--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -19,7 +19,7 @@ name: thingsboard
 description: A Helm chart for Thingsboard
 type: application
 version: 0.1.3
-appVersion: 3.4.1
+appVersion: 3.5.1
 icon: https://avatars.githubusercontent.com/u/24291394?s=200&v=4
 home: https://github.com/thingsboard/thingsboard-ce-k8s/
 dependencies:


### PR DESCRIPTION
This change syncs the version to the same value as in current default for `.Values.global.image.tag` which is `3.5.1`