### PR TITLE
feature(ha): Use Bitnami Common affinity templates

### DIFF
--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -37,3 +37,6 @@ dependencies:
   - name: redis
     version: 16.4.5
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  - name: common
+    version: 2.13.2
+    repository: oci://registry-1.docker.io/bitnamicharts

--- a/helm/thingsboard/templates/_helpers_midokura.tpl
+++ b/helm/thingsboard/templates/_helpers_midokura.tpl
@@ -1,0 +1,26 @@
+{{/*
+Add Bitnami-like affinity sections
+{{- include "midokura.affinity" (dict "service" .Values.someservice "podLabels" $podLabels "context" $) | nindent 6 }}
+*/}}
+{{- define "midokura.affinity" -}}
+{{- $context := .context -}}
+{{- $podLabels := .podLabels -}}
+{{- with .service -}}
+{{- if .affinity }}
+affinity: {{- include "common.tplvalues.render" (dict "value" .affinity "context" $) | nindent 2 }}
+{{- end }}
+{{- if or .podAffinityPreset .podAntiAffinityPreset .nodeAffinityPreset -}}
+affinity:
+  {{- if .podAffinityPreset }}
+  podAffinity: {{- include "common.affinities.pods" (dict "type" .podAffinityPreset "customLabels" $podLabels "context" $context) | nindent 4 }}
+  {{- end }}
+  {{- if .podAntiAffinityPreset }}
+  podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .podAntiAffinityPreset "customLabels" $podLabels "context" $context) | nindent 4 }}
+  {{- end }}
+  {{- if .nodeAffinityPreset }}
+  nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .nodeAffinityPreset.type "key" .nodeAffinityPreset.key "values" .nodeAffinityPreset.values) | nindent 4 }}
+  {{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+

--- a/helm/thingsboard/templates/coap-transport.yaml
+++ b/helm/thingsboard/templates/coap-transport.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     {{- include "thingsboard.labels" . | nindent 4 }}
 spec:
+{{- $podLabels := include "thingsboard.selectorLabels-coap" . }}
 {{- if not .Values.coap.autoscaling.enabled }}
   replicas: {{ .Values.coap.replicaCount }}
 {{- end }}
@@ -104,10 +105,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.coap.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "midokura.affinity" (dict "service" .Values.coap "podLabels" $podLabels "context" $) | nindent 6 }}
       {{- with .Values.coap.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/helm/thingsboard/templates/http-transport.yaml
+++ b/helm/thingsboard/templates/http-transport.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     {{- include "thingsboard.labels" . | nindent 4 }}
 spec:
+{{- $podLabels := include "thingsboard.selectorLabels-http" . }}
 {{- if not .Values.http.autoscaling.enabled }}
   replicas: {{ .Values.http.replicaCount }}
 {{- end }}
@@ -100,10 +101,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.http.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "midokura.affinity" (dict "service" .Values.http "podLabels" $podLabels "context" $) | nindent 6 }}
       {{- with .Values.http.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/helm/thingsboard/templates/mqtt-transport.yaml
+++ b/helm/thingsboard/templates/mqtt-transport.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     {{- include "thingsboard.labels" . | nindent 4 }}
 spec:
+{{- $podLabels := include "thingsboard.selectorLabels-mqtt" . }}
 {{- if not .Values.mqtt.autoscaling.enabled }}
   replicas: {{ .Values.mqtt.replicaCount }}
 {{- end }}
@@ -152,10 +153,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.mqtt.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "midokura.affinity" (dict "service" .Values.mqtt "podLabels" $podLabels "context" $) | nindent 6 }}
       {{- with .Values.mqtt.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     {{- include "thingsboard.labels" . | nindent 4 }}
 spec:
+  {{- $podLabels := include "thingsboard.selectorLabels-node" . }}
 {{- if not .Values.node.autoscaling.enabled }}
   replicas: {{ .Values.node.replicaCount }}
 {{- end }}
@@ -166,10 +167,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.node.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "midokura.affinity" (dict "service" .Values.node "podLabels" $podLabels "context" $) | nindent 6 -}}
       {{- with .Values.node.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This will allow easier and better setup of affinity on Thingsboard services, using same conventions as in Bitnami charts.

Related to: https://midokura.atlassian.net/browse/EVP-2685