### PR TITLE
chore(ci): bump chart-releaser-action to v1.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           version: v3.7.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.3.0
+        uses: helm/chart-releaser-action@v1.5.0
         with:
           charts_dir: helm
         env:


### PR DESCRIPTION
Bumping to v1.5.0.

Mostly to check if it can handle by default OCI repos (to avoid problems like https://github.com/midokura/thingsboard-ce-k8s/actions/runs/6483652142/job/17605731743#step:5:36).

OCI repos are the default in some cases (like Bitnami, see this [Bitnami blog entry](https://blog.bitnami.com/2023/04/httpsblog.bitnami.com202304bitnami-helm-charts-now-oci.html))