### PR TITLE
add(ttl): Added SQL ttl settings

### DIFF
--- a/helm/thingsboard/templates/node-db-configmap.yaml
+++ b/helm/thingsboard/templates/node-db-configmap.yaml
@@ -37,6 +37,11 @@ data:
   DATABASE_TS_TYPE: sql
   DATABASE_TS_LATEST_TYPE: sql
 {{- end }}
+{{- if not .Values.cassandra.enabled }}
+  SQL_TTL_TS_ENABLED: '{{ .Values.sql.ts.ttl.enabled }}'
+  SQL_TTL_TS_TS_KEY_VALUE_TTL: "{{ .Values.sql.ts.ttl.value }}"
+  SQL_TTL_TS_EXECUTION_INTERVAL: "{{ .Values.sql.ts.ttl.execution_interval }}"
+{{- end }}
   SPRING_JPA_DATABASE_PLATFORM: org.hibernate.dialect.PostgreSQLDialect
   SPRING_DRIVER_CLASS_NAME: org.postgresql.Driver
   {{ if index .Values "postgresql-ha" "enabled" }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -393,6 +393,10 @@ sql:
   ts:
     batch:
       threads: 10
+    ttl:
+      enabled: false
+      value: 86400000
+      execution_interval: 0
   ts-latest:
     batch:
       threads: 10


### PR DESCRIPTION
## background
- Currently, SQL ttl settings are set manually by editing the configmap after building evp-hub.
- Manual settings will require more effort, so you need to change it so that you can build an evp-hub that includes sql ttl settings.

## Fixes
- In the future, we will build evp-hub with values.yaml that describes SQL ttl settings.