### PR TITLE
fix(config): fix commit f2922f4

### DIFF
--- a/helm/thingsboard/templates/node-db-configmap.yaml
+++ b/helm/thingsboard/templates/node-db-configmap.yaml
@@ -38,9 +38,9 @@ data:
   DATABASE_TS_LATEST_TYPE: sql
 {{- end }}
 {{- if not .Values.cassandra.enabled }}
-  SQL_TTL_TS_ENABLED: '{{ .Values.sql.ts.ttl.enabled }}'
-  SQL_TTL_TS_TS_KEY_VALUE_TTL: "{{ .Values.sql.ts.ttl.value }}"
-  SQL_TTL_TS_EXECUTION_INTERVAL: "{{ .Values.sql.ts.ttl.execution_interval }}"
+  SQL_TTL_TS_ENABLED: {{ .Values.sql.ts.ttl.enabled | quote }}
+  SQL_TTL_TS_TS_KEY_VALUE_TTL: {{ int64 .Values.sql.ts.ttl.value | quote }}
+  SQL_TTL_TS_EXECUTION_INTERVAL: {{ int64 .Values.sql.ts.ttl.execution_interval | quote }}
 {{- end }}
   SPRING_JPA_DATABASE_PLATFORM: org.hibernate.dialect.PostgreSQLDialect
   SPRING_DRIVER_CLASS_NAME: org.postgresql.Driver

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -394,9 +394,9 @@ sql:
     batch:
       threads: 10
     ttl:
-      enabled: false
-      value: 86400000
-      execution_interval: 0
+      enabled: true
+      value: 0
+      execution_interval: 86400000
   ts-latest:
     batch:
       threads: 10


### PR DESCRIPTION
The values for 'value' and 'execution_interval' were swapped, which made ThingsBoard fail to deploy for two reasons:
- First, a recurring Helm issue converts long integers to scientific notation, and ThingsBoard failed to load a big SQL_TTL_TS_TS_KEY_VALUE_TTL as a long. With the correct values this will no longer be an issue, but I have ensured that they are not converted to scientific annotation anyway, in case someone ever tries to use a big integer there. I have fixed it the same way it was done here: https://github.com/midokura/evp-chart/pull/339.
- Second, ThingsBoard just does not work with an SQL_TTL_TS_EXECUTION_INTERVAL of 0, but that is fixed using the correct default

I have also change the default value of sql.ts.ttl.enabled, as it's true in ThingsBoard's code: https://github.com/thingsboard/thingsboard/blob/v3.5.1/application/src/main/resources/thingsboard.yml#L313


