### PR TITLE
fix(release): do not release on push to helmrepo w/o version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         with:
           charts_dir: helm
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
The workflow is run on every push to helmrepo. The intended usage of that branch is to push to it after merging with master and bumping the version, but someone could push to it by mistake for any other reason. In that case, the release would be overwritten.