### PR TITLE
Set datadog tags on container template too

### DIFF
--- a/helm/thingsboard/templates/mqtt-transport.yaml
+++ b/helm/thingsboard/templates/mqtt-transport.yaml
@@ -21,7 +21,6 @@ metadata:
   labels:
     tags.datadoghq.com/service: tb-mqtt-transport
     tags.datadoghq.com/version: {{ .appVersion }}
-    admission.datadoghq.com/enabled: "true"
     {{- include "thingsboard.labels" . | nindent 4 }}
 spec:
 {{- $podLabels := include "thingsboard.selectorLabels-mqtt" . }}
@@ -43,6 +42,9 @@ spec:
         admission.datadoghq.com/java-lib.version: latest
     {{- end }}
       labels:
+        tags.datadoghq.com/service: tb-mqtt-transport
+        tags.datadoghq.com/version: {{ .appVersion }}
+        admission.datadoghq.com/enabled: "true"
         {{- include "thingsboard.selectorLabels-mqtt" . | nindent 8 }}
     spec:
       {{- with .Values.mqtt.imagePullSecrets }}

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -21,7 +21,6 @@ metadata:
   labels:
     tags.datadoghq.com/service: tb-node
     tags.datadoghq.com/version: {{ .appVersion }}
-    admission.datadoghq.com/enabled: "true"
     {{- include "thingsboard.labels" . | nindent 4 }}
 spec:
   {{- $podLabels := include "thingsboard.selectorLabels-node" . }}
@@ -43,6 +42,9 @@ spec:
         admission.datadoghq.com/java-lib.version: latest
     {{- end }}
       labels:
+        tags.datadoghq.com/service: tb-node
+        tags.datadoghq.com/version: {{ .appVersion }}
+        admission.datadoghq.com/enabled: "true"
         {{- include "thingsboard.selectorLabels-node" . | nindent 8 }}
     spec:
       {{- with .Values.node.imagePullSecrets }}

--- a/helm/thingsboard/templates/web-ui.yaml
+++ b/helm/thingsboard/templates/web-ui.yaml
@@ -21,7 +21,6 @@ metadata:
   labels:
     tags.datadoghq.com/service: tb-ui
     tags.datadoghq.com/version: {{ .appVersion }}
-    admission.datadoghq.com/enabled: "true"
     {{- include "thingsboard.labels" . | nindent 4 }}
 spec:
 {{- if not .Values.webui.autoscaling.enabled }}
@@ -42,6 +41,9 @@ spec:
         admission.datadoghq.com/java-lib.version: latest
     {{- end }}
       labels:
+        tags.datadoghq.com/service: tb-ui
+        tags.datadoghq.com/version: {{ .appVersion }}
+        admission.datadoghq.com/enabled: "true"
         {{- include "thingsboard.selectorLabels-webui" . | nindent 8 }}
     spec:
       {{- with .Values.webui.imagePullSecrets }}


### PR DESCRIPTION
We noticed that the tags on container template is needed in order to
receive Thingsboard telemetry, beyond the tags on Deployment
