### PR TITLE
Add service mappings to thingsboard

### DIFF
--- a/helm/thingsboard/templates/mqtt-transport.yaml
+++ b/helm/thingsboard/templates/mqtt-transport.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ .Release.Name }}-mqtt-transport
   labels:
     tags.datadoghq.com/service: tb-mqtt-transport
-    tags.datadoghq.com/version: {{ .appVersion }}
+    tags.datadoghq.com/version: {{ .AppVersion }}
     {{- include "thingsboard.labels" . | nindent 4 }}
 spec:
 {{- $podLabels := include "thingsboard.selectorLabels-mqtt" . }}
@@ -43,7 +43,7 @@ spec:
     {{- end }}
       labels:
         tags.datadoghq.com/service: tb-mqtt-transport
-        tags.datadoghq.com/version: {{ .appVersion }}
+        tags.datadoghq.com/version: {{ .AppVersion }}
         admission.datadoghq.com/enabled: "true"
         {{- include "thingsboard.selectorLabels-mqtt" . | nindent 8 }}
     spec:

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ .Release.Name }}-node
   labels:
     tags.datadoghq.com/service: tb-node
-    tags.datadoghq.com/version: {{ .appVersion }}
+    tags.datadoghq.com/version: {{ .AppVersion }}
     {{- include "thingsboard.labels" . | nindent 4 }}
 spec:
   {{- $podLabels := include "thingsboard.selectorLabels-node" . }}
@@ -43,7 +43,7 @@ spec:
     {{- end }}
       labels:
         tags.datadoghq.com/service: tb-node
-        tags.datadoghq.com/version: {{ .appVersion }}
+        tags.datadoghq.com/version: {{ .AppVersion }}
         admission.datadoghq.com/enabled: "true"
         {{- include "thingsboard.selectorLabels-node" . | nindent 8 }}
     spec:
@@ -123,6 +123,8 @@ spec:
           {{- end }}
           - name: DEFAULT_INACTIVITY_TIMEOUT
             value: {{ .Values.node.state.defaultInactivityTimeoutInSec | default 600 | quote }}
+          - name: DD_SERVICE_MAPPING
+            value: "postgres:thingsboard-postgres"
           envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-node-db-config

--- a/helm/thingsboard/templates/web-ui.yaml
+++ b/helm/thingsboard/templates/web-ui.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ .Release.Name }}-web-ui
   labels:
     tags.datadoghq.com/service: tb-ui
-    tags.datadoghq.com/version: {{ .appVersion }}
+    tags.datadoghq.com/version: {{ .AppVersion }}
     {{- include "thingsboard.labels" . | nindent 4 }}
 spec:
 {{- if not .Values.webui.autoscaling.enabled }}
@@ -42,7 +42,7 @@ spec:
     {{- end }}
       labels:
         tags.datadoghq.com/service: tb-ui
-        tags.datadoghq.com/version: {{ .appVersion }}
+        tags.datadoghq.com/version: {{ .AppVersion }}
         admission.datadoghq.com/enabled: "true"
         {{- include "thingsboard.selectorLabels-webui" . | nindent 8 }}
     spec:


### PR DESCRIPTION
We want the database to be called 'thingsboard-postgres' and map with
current monitors.

Replace 'appVersion' with 'AppVersion' [1]

[1]: https://stackoverflow.com/questions/69817305/how-set-field-app-version-in-helm3-chart
