### PR TITLE
Update ingress.yaml to fix missing api

### DIFF
--- a/helm/thingsboard/templates/ingress.yaml
+++ b/helm/thingsboard/templates/ingress.yaml
@@ -50,6 +50,13 @@ spec:
                 name: {{ $releaseName }}-http
                 port:
                   number: {{ $values.http.service.port }}
+          - path: /api
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $releaseName }}-node
+                port:
+                  number: {{ $values.node.service.port }}
           - path: /api/.*
             pathType: ImplementationSpecific
             backend:


### PR DESCRIPTION
Missing api ingress path causes authentication failures with 404 due to api not found