### PR TITLE
set containerSecurityContext on EVP2 Hub ThingsBoard

### DIFF
--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -371,6 +371,10 @@ redis:
     replicaCount: 0
     persistence:
       enabled: false
+    containerSecurityContext:
+      enabled: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
 
 kafka:
   persistence:


### PR DESCRIPTION
in evp1 we had this:

https://github.com/midokura/thingsboard-private/blob/3932b1c4497f83f3cc9c8e65cc53d1fc0b2e996f/k8s/charts/thingsboard/values.yaml#L241

any reason not to enable it for evp2? is it already enabled by default maybe?