### PR TITLE
fix: improve log configuration

### DIFF
--- a/helm/thingsboard/templates/js-executor.yaml
+++ b/helm/thingsboard/templates/js-executor.yaml
@@ -69,7 +69,7 @@ spec:
           - name: TB_QUEUE_KAFKA_REPLICATION_FACTOR
             value: "{{ .Values.kafka.offsetsTopicReplicationFactor }}"
           - name: LOGGER_LEVEL
-            value: "info"
+            value: "{{ .Values.jsexecutor.logger.level }}"
           - name: LOG_FOLDER
             value: "logs"
           - name: LOGGER_FILENAME

--- a/helm/thingsboard/templates/node-configmap.yaml
+++ b/helm/thingsboard/templates/node-configmap.yaml
@@ -69,14 +69,13 @@ data:
 {{- end }}
           </appender>
 
-          <logger name="org.thingsboard.server" level="INFO" />
-          <logger name="com.google.common.util.concurrent.AggregateFuture" level="OFF" />
-
-          <root level="INFO">
+          <root level="{{ .Values.node.log.root.level }}">
+              {{- if .Values.node.log.fileAppenderEnabled }}
               <appender-ref ref="fileLogAppender"/>
+              {{- end }}
               <appender-ref ref="STDOUT"/>
           </root>
-          {{- range $v := .Values.node.loggers }}
+          {{- range $v := .Values.node.log.loggers }}
           {{ $v }}
           {{- end }}
 

--- a/helm/thingsboard/templates/transport-configmap.yaml
+++ b/helm/thingsboard/templates/transport-configmap.yaml
@@ -59,10 +59,13 @@ data:
 {{- end }}
           </appender>
 
-          <logger name="org.thingsboard.server" level="INFO" />
-          <root level="INFO">
+          <root level="{{ $values.mqtt.log.root.level }}">
               <appender-ref ref="STDOUT"/>
           </root>
+
+          {{- range $v := $values.mqtt.log.loggers }}
+          {{ $v }}
+          {{- end }}
       </configuration>
 
 ---

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -55,7 +55,13 @@ node:
   kind: StatefulSet
   loadDemo: false
   replicaCount: 1
-  loggers: []
+  log:
+    fileAppenderEnabled: false
+    root:
+      level: WARN
+    loggers:
+      - <logger name="org.thingsboard.server" level="WARN" />
+      - <logger name="com.google.common.util.concurrent.AggregateFuture" level="OFF" />
   image:
     repository: thingsboard/tb-node
     # Overrides the global image values
@@ -119,6 +125,8 @@ jsexecutor:
     #server: docker.io
     #pullPolicy: Always
     #tag: "X.Y.Z"
+  logger:
+    level: warn
   replicaCount: 5
   podAnnotations: {}
   podSecurityContext: {}
@@ -144,6 +152,11 @@ mqtt:
     #pullPolicy: Always
     #tag: "X.Y.Z"
   replicaCount: 1
+  log:
+    root:
+      level: WARN
+    loggers:
+      - <logger name="org.thingsboard.server" level="WARN" />
   ssl:
     enabled: false
     secret: kubernetes-secret


### PR DESCRIPTION
We had hardcoded values for logging in this components that should be configurable with Values. Now we can configure log levels in node, mqtt and js executor. We can configure loggers for node and mqtt components. We also can enable/disable file log appending, which is not always necessary.