### PR TITLE
minimize partitions

### DIFF
--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -65,6 +65,10 @@ spec:
           image: {{ include "thingsboard.postgresImage" . }}
           command: ['sh', '-c',
             'export PGPASSWORD=''{{ index .Values "postgresql-ha" "postgresql" "password" }}'' && export row_count=0 && until [ $row_count -ge 3 ]; do sleep 1; row_count=$(psql -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }} -U {{ index .Values "postgresql-ha" "postgresql" "username" }} -d {{ index .Values "postgresql-ha" "postgresql" "database" }} --set=on_error_stop=1 -t -c "SELECT count(*) FROM queue;"); done;']
+        - name: set-partitions-db-queue
+          image: {{ include "thingsboard.postgresImage" . }}
+          command: ['sh', '-c',
+            'export PGPASSWORD=''{{ index .Values "postgresql-ha" "postgresql" "password" }}'' && psql -h ''{{ include "thingsboard.pgpoolservicename" . }}'' -p {{ index .Values "postgresql-ha" "pgpool" "containerPorts" "postgresql" }} -U {{ index .Values "postgresql-ha" "postgresql" "username" }} -d {{ index .Values "postgresql-ha" "postgresql" "database" }} --set=on_error_stop=1 -t -c "UPDATE queue set partitions={{ .Values.kafka.queues.numPartitions }};"']
         {{- end  }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -393,6 +393,8 @@ kafka:
   zookeeper:
     persistence:
       enabled: false
+  queues:
+    numPartitions: 2
 
 sql:
   attributes:


### PR DESCRIPTION
The number of partitions is minimized to 2 in order to minimize
evp-tb-repartitioner pods running. This should help to minimize required
resources for starting evp.

For now the change is applied only when the database is managed locally.

jira-task: https://midokura.atlassian.net/browse/EVP-3626
<details>
<summary>
Committer details
</summary>
Local-Branch: evp-3626
</details>