### PR TITLE
fix(jsexecutor): fix jexecutorSelector to nodeSelector

### DIFF
--- a/helm/thingsboard/templates/js-executor.yaml
+++ b/helm/thingsboard/templates/js-executor.yaml
@@ -80,8 +80,8 @@ spec:
             value: "1000"
           resources:
             {{- toYaml .Values.jsexecutor.resources | nindent 12 }}
-      {{- with .Values.jsexecutor.jsexecutorSelector }}
-      jsexecutorSelector:
+      {{- with .Values.jsexecutor.nodeSelector }}
+      nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.jsexecutor.affinity }}


### PR DESCRIPTION
## background
・The js-excuter node selector is supported, but it is incorrect and the js-excuter Pod cannot be placed on a specific node.
・If a Pod cannot be placed on a specific node, it may affect the resources of that node if it is placed on another node, so I would like to fix this.

## Fixes
　Change the description of "jexecutorSelector" in js-excuter to "nodeSelector"
