### PR TITLE
fix: use the same credentials

### DIFF
--- a/helm/thingsboard/templates/initializedb-job.yaml
+++ b/helm/thingsboard/templates/initializedb-job.yaml
@@ -25,8 +25,10 @@ spec:
   ttlSecondsAfterFinished: 0
   template:
     spec:
+      {{- with .Values.node.imagePullSecrets }}
       imagePullSecrets:
-        - name: '{{ .Release.Name }}-container-registry'
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         {{- if (index .Values "postgresql-ha" "enabled") }}
         - name: check-postgres-db-ready


### PR DESCRIPTION
Initializa db job uses the same image used for tb-node, so it should be
retrieved by using the same credentials.
<details>
<summary>
Committer details
</summary>
Local-Branch: master
</details>