### PR TITLE
Pin DD dd-trace-java version to v1.45.2

### DIFF
--- a/helm/thingsboard/templates/mqtt-transport.yaml
+++ b/helm/thingsboard/templates/mqtt-transport.yaml
@@ -41,7 +41,7 @@ spec:
     {{- with .Values.mqtt.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
-        admission.datadoghq.com/java-lib.version: latest
+        admission.datadoghq.com/java-lib.version: v1.45.2
     {{- end }}
       labels:
         tags.datadoghq.com/service: tb-mqtt-transport

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -39,7 +39,7 @@ spec:
     {{- with .Values.node.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
-        admission.datadoghq.com/java-lib.version: latest
+        admission.datadoghq.com/java-lib.version: v1.45.2
     {{- end }}
       labels:
         tags.datadoghq.com/service: tb-node

--- a/helm/thingsboard/templates/web-ui.yaml
+++ b/helm/thingsboard/templates/web-ui.yaml
@@ -38,7 +38,7 @@ spec:
     {{- with .Values.webui.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
-        admission.datadoghq.com/java-lib.version: latest
+        admission.datadoghq.com/java-lib.version: v1.45.2
     {{- end }}
       labels:
         tags.datadoghq.com/service: tb-ui


### PR DESCRIPTION
Pin version to latest available [`v1.45.2`](https://github.com/DataDog/dd-trace-java/releases/tag/v1.45.2)