### PR TITLE
feature(tbRemoval): evp-mqtt feature flag

### DIFF
--- a/helm/thingsboard/templates/evp-mqtt-transport.yaml
+++ b/helm/thingsboard/templates/evp-mqtt-transport.yaml
@@ -49,10 +49,8 @@ spec:
         admission.datadoghq.com/enabled: "true"
         {{- include "thingsboard.selectorLabels-mqtt" . | nindent 8 }}
     spec:
-      {{- with .Values.mqtt.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        - {{ .Release.Name }}-evp-container-registry
       serviceAccountName: {{ include "thingsboard.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.mqtt.podSecurityContext | nindent 8 }}

--- a/helm/thingsboard/templates/evp-mqtt-transport.yaml
+++ b/helm/thingsboard/templates/evp-mqtt-transport.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-{{- if not .Values.tbRemoval.evpMqtt.enabled }}
+{{- if .Values.tbRemoval.evpMqtt.enabled }}
 apiVersion: apps/v1
 kind: {{ .Values.mqtt.kind }}
 metadata:
@@ -60,7 +60,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.mqtt.securityContext | nindent 12 }}
-          image: "{{ .Values.mqtt.image.server | default .Values.global.image.server }}/{{ .Values.mqtt.image.repository }}:{{ .Values.mqtt.image.tag | default .Values.global.image.tag }}"
+          image: "{{ .Values.mqtt.evpImage }}"
           imagePullPolicy: {{ .Values.mqtt.image.pullPolicy | default .Values.global.image.pullPolicy}}
           ports:
           - containerPort: {{ .Values.mqtt.port.number }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -25,6 +25,10 @@ global:
 nameOverride: ""
 fullnameOverride: ""
 
+tbRemoval:
+  evpMqtt:
+    enabled: false
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -145,6 +149,7 @@ jsexecutor:
 mqtt:
   # kind can be either Deployment or StatefulSet
   kind: StatefulSet
+  evpImage: ghcr.io/midokura/evp-mqtt:3.5.1-mido-c3354cf56e913657d6386e6d8f2c8f5d8d329a8f 
   image:
     repository: thingsboard/tb-mqtt-transport
     # Overrides the global image values


### PR DESCRIPTION
Adding the feature flag to manage the mqtt component to use.

```
tbRemoval:
  evpMqtt:
    enabled: false
```

ThingsBoard's component will be used by default or when 'false'

Change-Id: I4849aa971e2b34288445150f4a01d1fc9a9d6785
jira-task: https://aitrios.atlassian.net/browse/CTRL-4450