### PR TITLE
feature(tbremoval): update evp-mqtt image

### DIFF
--- a/.github/workflows/chart-force-update-image.yaml
+++ b/.github/workflows/chart-force-update-image.yaml
@@ -1,0 +1,35 @@
+name: Force update EVP-MQTT image
+
+on:
+  workflow_call:
+    inputs:
+      evpMqttImage:
+        description: 'EVP MQTT image you want to set'
+        required: false
+        type: string      
+
+  workflow_dispatch:
+    inputs:
+      evpMqttImage:
+        description: 'EVP MQTT image you want to set'
+        required: false
+
+jobs:
+  update-dependencies:
+    runs-on: [self-hosted, evp-cloud, amd64, stable]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: midokura/thingsboard-ce-k8s
+          ref: helmrepo
+          fetch-depth: 0 # It is needed to not have problems when pushing changes
+          token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Config git email and name
+        run: |
+          git config --global user.email "evp-cloud@midokura.com"
+          git config --global user.name "EVP cloud automation"
+
+      - name: Change Docker image versions in the chart and release new version
+        run: .github/workflows/force_update_images.sh "${{ github.event.inputs.evpMqttImage || inputs.evpMqttImage }}"

--- a/.github/workflows/force_update_images.sh
+++ b/.github/workflows/force_update_images.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+evp_mqtt_image="${1:-$EVP_MQTT_IMAGE}"
+git_branch="helmrepo"
+
+if [[ -z "$evp_mqtt_image" ]]
+then
+  echo "the evp_mqtt_image must not be empty"
+  exit 1
+fi
+
+set -x
+
+echo Git branch: "$git_branch"
+
+values_file=helm/thingsboard/values.yaml
+chart_file=helm/thingsboard/Chart.yaml
+
+if [[ "$evp_mqtt_image" ]]
+then
+  yq -i e '.mqtt.evpImage="'"$evp_mqtt_image"'"' "$values_file"
+fi
+
+current_version=$(yq '.version' $chart_file)
+
+# Extract base and last number using regex
+base="${current_version%.*}"
+last="${current_version##*.}"
+
+# Increment the last number
+((last++))
+
+# Combine again
+new_version="${base}.${last}"
+
+echo "$new_version"
+
+#Update the version in the chart
+yq -i e '.version="'"$new_version"'"' "$chart_file"
+
+git commit -a -m "bump evp-mqtt image to $evp_mqtt_image and release chart to $new_version"
+git push --set-upstream origin "$git_branch"

--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 name: thingsboard
 description: A Helm chart for Thingsboard
 type: application
-version: 0.1.4-rc.46
+version: 0.1.4-rc.47
 appVersion: 3.5.1
 icon: https://avatars.githubusercontent.com/u/24291394?s=200&v=4
 home: https://github.com/thingsboard/thingsboard-ce-k8s/


### PR DESCRIPTION
The workflow will be called from main branch of evp-mqtt repository to update the image of the evp-mqtt.
The version of the chart is also updated automatically in order to publish it.

Change-Id: Ia21ebf1c822cbf2690b34ee65c7bb9485cfaf7c2
jira-task: https://aitrios.atlassian.net/browse/CTRL-4450