### PR TITLE
use standard properties for docker images

### DIFF
--- a/helm/thingsboard/templates/evp-mqtt-transport.yaml
+++ b/helm/thingsboard/templates/evp-mqtt-transport.yaml
@@ -60,7 +60,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.mqtt.securityContext | nindent 12 }}
-          image: "{{ .Values.mqtt.evpImage }}"
+          image: "{{ .Values.mqtt.evp.image.server }}/{{ .Values.mqtt.evp.image.repository }}:{{ .Values.mqtt.evp.image.tag }}"
           imagePullPolicy: {{ .Values.mqtt.image.pullPolicy | default .Values.global.image.pullPolicy}}
           ports:
           - containerPort: {{ .Values.mqtt.port.number }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -149,7 +149,11 @@ jsexecutor:
 mqtt:
   # kind can be either Deployment or StatefulSet
   kind: StatefulSet
-  evpImage: ghcr.io/midokura/evp-mqtt:3.5.1-mido-c3354cf56e913657d6386e6d8f2c8f5d8d329a8f 
+  evp:
+    image:
+      server: setplease
+      repository: setplease
+      tag: setplease
   image:
     repository: thingsboard/tb-mqtt-transport
     # Overrides the global image values


### PR DESCRIPTION
using image with server repository and tag helps renovate to update the images as a new version is available.

Evp images are now homogeneous to thingsboard's ones.

Change-Id: I5a806de03814d568c280d3769756ef524eba82bc