### PR TITLE
Add EVP feature flags in an optional ConfigMap

### DIFF
--- a/helm/thingsboard/templates/evp-mqtt-transport-featureflags-configmap.yaml
+++ b/helm/thingsboard/templates/evp-mqtt-transport-featureflags-configmap.yaml
@@ -22,7 +22,7 @@ metadata:
     name: '{{ .Release.Name }}-mqtt-transport-featureflags'
     {{- include "thingsboard.labels" . | nindent 4 }}
 data:
-  evp-mqtt-config: |-
+  evp-mqtt-config.yaml: |-
     evp:
       features:
         queue-routing-information:

--- a/helm/thingsboard/templates/evp-mqtt-transport-featureflags-configmap.yaml
+++ b/helm/thingsboard/templates/evp-mqtt-transport-featureflags-configmap.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.evp.mqtt.enabled }}
+#
+# Copyright © 2016-2020 The Thingsboard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-mqtt-transport-featureflags
+  labels:
+    name: '{{ .Release.Name }}-mqtt-transport-featureflags'
+    {{- include "thingsboard.labels" . | nindent 4 }}
+data:
+  evp-mqtt-config: |-
+    evp:
+      features:
+        queue-routing-information:
+          enabled: {{ .Values.evp.mqtt.queueRoutingInformation | default false }}
+        tls-device-certificate-validation:
+          enabled: {{ .Values.evp.mqtt.tlsDeviceCertificateValidation | default false }}
+        mqtt-connect-handling:
+          enabled: {{ .Values.evp.mqtt.mqttConnectHandling | default false }}
+        tenant-profile-request-handling:
+          enabled: {{ .Values.evp.mqtt.tenantProfileRequestHandling | default false }}
+        device-profile-request-handling:
+          enabled: {{ .Values.evp.mqtt.deviceProfileRequestHandling | default false }}
+{{- end }}

--- a/helm/thingsboard/templates/evp-mqtt-transport.yaml
+++ b/helm/thingsboard/templates/evp-mqtt-transport.yaml
@@ -112,6 +112,8 @@ spec:
           - name: MQTT_BIND_PORT
             value: "{{ .Values.mqtt.port.number }}"
           {{- end }}
+          - name: EVP_CONFIG_PATH
+            value: /evp-config/evp-mqtt-config.yaml
           {{- range .Values.mqtt.extraEnvVars }}
           - name: {{ .key | upper  }}
             value: {{ .value | quote }}
@@ -119,6 +121,8 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: {{ .Release.Name }}-mqtt-transport-config
+            - mountPath: /evp-config
+              name: {{ .Release.Name }}-mqtt-transport-featureflags
           {{- if eq .Values.mqtt.ssl.enabled true }}
             - mountPath: /mqtt-certs
               name: mqtt-certs
@@ -144,6 +148,12 @@ spec:
               path:  tb-mqtt-transport.conf
             - key: logback
               path:  logback.xml
+        - name: {{ .Release.Name }}-mqtt-transport-featureflags
+          configMap:
+            name: {{ .Release.Name }}-mqtt-transport-featureflags
+            items:
+            - key: evp-mqtt-config
+              path: evp-mqtt-config.yaml
         - name: {{ .Release.Name }}-node-logs
           emptyDir: {}
         {{- if eq .Values.mqtt.ssl.enabled true }}

--- a/helm/thingsboard/templates/evp-mqtt-transport.yaml
+++ b/helm/thingsboard/templates/evp-mqtt-transport.yaml
@@ -151,9 +151,6 @@ spec:
         - name: {{ .Release.Name }}-mqtt-transport-featureflags
           configMap:
             name: {{ .Release.Name }}-mqtt-transport-featureflags
-            items:
-            - key: evp-mqtt-config
-              path: evp-mqtt-config.yaml
         - name: {{ .Release.Name }}-node-logs
           emptyDir: {}
         {{- if eq .Values.mqtt.ssl.enabled true }}


### PR DESCRIPTION
This change adds an optional `evp-mqtt-config.yaml` that contains the feature flag configuration for all the current and future changes that will be added to the MQTT broker in the effort to remove ThingsBoard.

The purpose of adding these early is to create CI pipelines that can enable them for current and future EVP e2e tests.

The change will only be visible if `evp.mqtt.enabled` is `true`, so these features are not accessible in environments until we are ready to expose them.

The feature flags are not mentioned in the `values.yaml` to avoid confusion in the majority of deployments -  since they are not needed/wanted. They can be added once they are ready for deployment.

JIRA: https://aitrios.atlassian.net/browse/CTRL-4476