### PR TITLE
add evp features transparently

### DIFF
--- a/helm/thingsboard/templates/evp-mqtt-transport-featureflags-configmap.yaml
+++ b/helm/thingsboard/templates/evp-mqtt-transport-featureflags-configmap.yaml
@@ -25,14 +25,7 @@ data:
   evp-mqtt-config.yaml: |-
     evp:
       features:
-        queue-routing-information:
-          enabled: {{ .Values.evp.mqtt.queueRoutingInformation | default false }}
-        tls-device-certificate-validation:
-          enabled: {{ .Values.evp.mqtt.tlsDeviceCertificateValidation | default false }}
-        mqtt-connect-handling:
-          enabled: {{ .Values.evp.mqtt.mqttConnectHandling | default false }}
-        tenant-profile-request-handling:
-          enabled: {{ .Values.evp.mqtt.tenantProfileRequestHandling | default false }}
-        device-profile-request-handling:
-          enabled: {{ .Values.evp.mqtt.deviceProfileRequestHandling | default false }}
+        {{- if .Values.evp.features }}
+          {{- toYaml .Values.evp.features | nindent 8 }}
+        {{- end}}
 {{- end }}


### PR DESCRIPTION
This PR allows to update the features without having to release a new version of the chart everytime a new one is added. All the features are copied directly to the configmap.

Change-Id: I9a99a195eb0f5ab7f2a91edd9e8ce461fdf52302