### PR TITLE
Upgrade kafka chart version

### DIFF
--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -32,7 +32,7 @@ dependencies:
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: cassandra.enabled
   - name: kafka
-    version: 15.3.4
+    version: 19.1.5
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   - name: redis
     version: 16.4.5

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -397,9 +397,13 @@ redis:
       enabled: false
 
 kafka:
+  image:
+    tag: 3.1.0-debian-10-r31
   persistence:
     enabled: false
   zookeeper:
+    image:
+      tag: 3.7.0-debian-10-r303
     persistence:
       enabled: false
 


### PR DESCRIPTION
Upgrade the version of the chart from 15.3.4 to 19.1.5, which supports
a "new" `service.headless.publishNotReadyAddresses` that should allow
Kafka pods start synchronizing each other and being published in the
service before the readiness probe is successful.

At the same time, pin kafka and zookeeper image tags to the one we are using
right now.

According to [upgrade docs], it should only affect the Zookeeper
version, and we shouldn't experience any error on the configuration
values we use right now.

I did a small upgrade test in a separate cluster and it worked
successfully, so hopefully the new Zookeeper version will not affect
our cluster. Unfortunately, I think we cannot tell exactly until we
run all the PDCs in SIE env.

Implements: https://aitrios.atlassian.net/browse/REL-3715

[upgrade docs]: https://artifacthub.io/packages/helm/bitnami/kafka#upgrading
