### PR TITLE
Migrate from bitnami to bitnamilegacy.

### DIFF
--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -395,14 +395,19 @@ redis:
     replicaCount: 0
     persistence:
       enabled: false
+  image:
+    repository: bitnamilegacy/redis
+    tag: 6.2.6
 
 kafka:
   image:
-    tag: 3.1.0-debian-10-r31
+    repository: bitnamilegacy/kafka
+    tag: 3.1.0
   persistence:
     enabled: false
   zookeeper:
     image:
+      repository: bitnamilegacy/zookeeper
       tag: 3.7.0-debian-10-r303
     persistence:
       enabled: false


### PR DESCRIPTION
Bitnami [has announced that ](https://github.com/bitnami/charts/issues/35164), effective from 28th August, its dockerhub repository will only have the latest tag.

We are migrating all our bitnami images to bitnamilegacy.

Check that images exists in new repositories
- https://hub.docker.com/layers/bitnamilegacy/zookeeper/3.7.0-debian-10-r303/images/sha256-f19b07a03cc434275c27da9152681777ca75631361ab818f08344232354fc931
- https://hub.docker.com/layers/bitnamilegacy/kafka/3.1.0/images/sha256-bb3a49ebb0e3eb82dc200a92ce5998c2f138b3d259a276855aba1141c333ab9a
- https://hub.docker.com/layers/bitnamilegacy/redis/6.2.6/images/sha256-1f094472b824a07d3a637b7cb4195352c565a28fb5c0960044f20330b02c784f