### PR TITLE
Use the available bitnami legacy zookeeper version

### DIFF
--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -408,7 +408,7 @@ kafka:
   zookeeper:
     image:
       repository: bitnamilegacy/zookeeper
-      tag: 3.7.0-debian-10-r303
+      tag: 3.7.0
     persistence:
       enabled: false
 


### PR DESCRIPTION
Bitnami legacy is under some migrations and they changed the tag of the
image.

We need to set the right tag to use the ZK v3.7.0 running on Debian 10:
https://hub.docker.com/layers/bitnamilegacy/zookeeper/3.7.0/images/sha256-c7674f70c56441532ba23b31791ae8ef9b980f2d59c3cd7dbde1ea9cd85d37b4

Related #91
