### PR TITLE
evp-mqtt logs in json format

### DIFF
--- a/helm/thingsboard/templates/transport-configmap.yaml
+++ b/helm/thingsboard/templates/transport-configmap.yaml
@@ -41,10 +41,10 @@ data:
 
           <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 
-{{- if $values.global.jsonLogs }}
+{{- if $values.evp.mqtt.enabled }}
               <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
                   <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
-                      <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+                      <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSSSSX</timestampFormat>
                       <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
                       <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
                           <prettyPrint>false</prettyPrint>


### PR DESCRIPTION
This PR configures the evp-mqtt component for logging in json format independently of the global.jsonLogs parameter that is used in other components and cannot be enabled.

Change-Id: Ib65015c0f4ace5436fe1928bd7106ac85eaf374b