### PR TITLE
make node image configurable for evp

### DIFF
--- a/helm/thingsboard/templates/evp-node.yaml
+++ b/helm/thingsboard/templates/evp-node.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-{{- if not .Values.evp.node.enabled }}
+{{- if .Values.evp.node.enabled }}
 apiVersion: apps/v1
 kind: {{ .Values.node.kind }}
 metadata:
@@ -70,7 +70,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.node.securityContext | nindent 12 }}
-          image: "{{ .Values.node.image.server | default .Values.global.image.server }}/{{ .Values.node.image.repository }}:{{ .Values.node.image.tag | default .Values.global.image.tag }}"
+          image: "{{ .Values.node.evp.image.server }}/{{ .Values.node.evp.image.repository }}:{{ .Values.node.evp.image.tag }}"
           imagePullPolicy: {{ .Values.node.image.pullPolicy | default .Values.global.image.pullPolicy}}
           ports:
           - containerPort: {{ .Values.node.port.http }}

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -28,6 +28,8 @@ fullnameOverride: ""
 evp:
   mqtt:
     enabled: false
+  node:
+    enabled: false
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -59,6 +61,11 @@ node:
   kind: StatefulSet
   loadDemo: false
   replicaCount: 1
+  evp:
+    image:
+      server: setplease
+      repository: setplease
+      tag: setplease
   log:
     fileAppenderEnabled: false
     root:


### PR DESCRIPTION
Two different images can be used as node component. The image from
Thingsboard or the one coming from EVP.
```
evp:
  node:
    enabled: false
```
This PR adds the feature flag to select the node component to use.
ThingsBoard's component will be used by default or when 'false'

The file evp-node.yaml  is added to be updated with any setup related to
evp image without having to touch the one from thingsboard, minimizing
any issue just because the same file is updated.

The images will be set up in evp-chart and not in this repository
because this is public.

Change-Id: Id019f6d80d4cd6bda5ac072756f17fb5014547d1