### PR TITLE
feat(kafka): Make TB_KAFKA_SERVERS configurable via global.kafka

### DIFF
--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 name: thingsboard
 description: A Helm chart for Thingsboard
 type: application
-version: 0.1.4-rc.57
+version: 0.1.4-rc.58
 appVersion: 3.5.1
 icon: https://avatars.githubusercontent.com/u/24291394?s=200&v=4
 home: https://github.com/thingsboard/thingsboard-ce-k8s/

--- a/helm/thingsboard/templates/coap-transport.yaml
+++ b/helm/thingsboard/templates/coap-transport.yaml
@@ -86,7 +86,7 @@ spec:
           - name: COAP_TIMEOUT
             value: "{{ .Values.coap.timeout }}"
           - name: TB_KAFKA_SERVERS
-            value: "{{ .Release.Name }}-kafka:{{ .Values.kafka.service.ports.client }}"
+            value: "{{ .Values.global.kafka.bootstrapServer | default (printf "%s-kafka" .Release.Name) }}:{{ .Values.global.kafka.port | default .Values.kafka.service.ports.client }}"
           - name: TB_QUEUE_KAFKA_REPLICATION_FACTOR
             value: "{{ .Values.kafka.offsetsTopicReplicationFactor }}"
           volumeMounts:

--- a/helm/thingsboard/templates/evp-mqtt-transport.yaml
+++ b/helm/thingsboard/templates/evp-mqtt-transport.yaml
@@ -78,7 +78,7 @@ spec:
           - name: MQTT_TIMEOUT
             value: "{{ .Values.mqtt.timeout }}"
           - name: TB_KAFKA_SERVERS
-            value: "{{ .Release.Name }}-kafka:{{ .Values.kafka.service.ports.client }}"
+            value: "{{ .Values.global.kafka.bootstrapServer | default (printf "%s-kafka" .Release.Name) }}:{{ .Values.global.kafka.port | default .Values.kafka.service.ports.client }}"
           - name: TB_QUEUE_KAFKA_REPLICATION_FACTOR
             value: "{{ .Values.kafka.offsetsTopicReplicationFactor }}"
           {{- if eq .Values.monitoring.enabled true }}

--- a/helm/thingsboard/templates/evp-node.yaml
+++ b/helm/thingsboard/templates/evp-node.yaml
@@ -102,7 +102,7 @@ spec:
           - name: ZOOKEEPER_URL
             value: "{{ .Release.Name }}-zookeeper:{{ .Values.kafka.zookeeper.containerPorts.client }}"
           - name: TB_KAFKA_SERVERS
-            value: "{{ .Release.Name }}-kafka:{{ .Values.kafka.service.ports.client }}"
+            value: "{{ .Values.global.kafka.bootstrapServer | default (printf "%s-kafka" .Release.Name) }}:{{ .Values.global.kafka.port | default .Values.kafka.service.ports.client }}"
           - name: TB_QUEUE_KAFKA_REPLICATION_FACTOR
             value: "{{ .Values.kafka.offsetsTopicReplicationFactor }}"
           - name: JS_EVALUATOR

--- a/helm/thingsboard/templates/http-transport.yaml
+++ b/helm/thingsboard/templates/http-transport.yaml
@@ -73,7 +73,7 @@ spec:
           - name: HTTP_REQUEST_TIMEOUT
             value: "{{ .Values.http.timeout }}"
           - name: TB_KAFKA_SERVERS
-            value: "{{ .Release.Name }}-kafka:{{ .Values.kafka.service.ports.client }}"
+            value: "{{ .Values.global.kafka.bootstrapServer | default (printf "%s-kafka" .Release.Name) }}:{{ .Values.global.kafka.port | default .Values.kafka.service.ports.client }}"
           - name: TB_QUEUE_KAFKA_REPLICATION_FACTOR
             value: "{{ .Values.kafka.offsetsTopicReplicationFactor }}"
           volumeMounts:

--- a/helm/thingsboard/templates/js-executor.yaml
+++ b/helm/thingsboard/templates/js-executor.yaml
@@ -69,7 +69,7 @@ spec:
           - name: REMOTE_JS_EVAL_REQUEST_TOPIC
             value: "js_eval.requests"
           - name: TB_KAFKA_SERVERS
-            value: "{{ .Release.Name }}-kafka:{{ .Values.kafka.service.ports.client }}"
+            value: "{{ .Values.global.kafka.bootstrapServer | default (printf "%s-kafka" .Release.Name) }}:{{ .Values.global.kafka.port | default .Values.kafka.service.ports.client }}"
           - name: TB_QUEUE_KAFKA_REPLICATION_FACTOR
             value: "{{ .Values.kafka.offsetsTopicReplicationFactor }}"
           - name: LOGGER_LEVEL

--- a/helm/thingsboard/templates/mqtt-transport.yaml
+++ b/helm/thingsboard/templates/mqtt-transport.yaml
@@ -78,7 +78,7 @@ spec:
           - name: MQTT_TIMEOUT
             value: "{{ .Values.mqtt.timeout }}"
           - name: TB_KAFKA_SERVERS
-            value: "{{ .Release.Name }}-kafka:{{ .Values.kafka.service.ports.client }}"
+            value: "{{ .Values.global.kafka.bootstrapServer | default (printf "%s-kafka" .Release.Name) }}:{{ .Values.global.kafka.port | default .Values.kafka.service.ports.client }}"
           - name: TB_QUEUE_KAFKA_REPLICATION_FACTOR
             value: "{{ .Values.kafka.offsetsTopicReplicationFactor }}"
           {{- if eq .Values.monitoring.enabled true }}

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -102,7 +102,7 @@ spec:
           - name: ZOOKEEPER_URL
             value: "{{ .Release.Name }}-zookeeper:{{ .Values.kafka.zookeeper.containerPorts.client }}"
           - name: TB_KAFKA_SERVERS
-            value: "{{ .Release.Name }}-kafka:{{ .Values.kafka.service.ports.client }}"
+            value: "{{ .Values.global.kafka.bootstrapServer | default (printf "%s-kafka" .Release.Name) }}:{{ .Values.global.kafka.port | default .Values.kafka.service.ports.client }}"
           - name: TB_QUEUE_KAFKA_REPLICATION_FACTOR
             value: "{{ .Values.kafka.offsetsTopicReplicationFactor }}"
           - name: JS_EVALUATOR


### PR DESCRIPTION
## Summary
- Make `TB_KAFKA_SERVERS` configurable via `global.kafka.bootstrapServer` and `global.kafka.port`
- Falls back to `{{ .Release.Name }}-kafka:{{ .Values.kafka.service.ports.client }}` when not set (backwards compatible)
- Bump chart version to `0.1.4-rc.58`

## Context
When migrating from the embedded ThingsBoard Kafka to an external Kafka cluster (e.g. bitnami-kafka), `TB_KAFKA_SERVERS` was hardcoded to `{{ .Release.Name }}-kafka` and could not be overridden by the parent chart. This meant that changing `global.kafka.bootstrapServer` in the parent chart (evp-chart) had no effect on ThingsBoard components.

## Changed templates
- `evp-mqtt-transport.yaml`
- `mqtt-transport.yaml`
- `evp-node.yaml`
- `node.yaml`
- `coap-transport.yaml`
- `http-transport.yaml`
- `js-executor.yaml`

## Test plan
- [ ] Verify default behavior unchanged (no `global.kafka` set → uses `evp-kafka:9092`)
- [ ] Verify override works (`global.kafka.bootstrapServer: evp-kafka-bitnami` → uses `evp-kafka-bitnami:9092`)
- [ ] Deploy to demo-jp and confirm MQTT transport connects to bitnami-kafka

🤖 Generated with [Claude Code](https://claude.com/claude-code)