### PR TITLE
feat: Make MQTT service creation configurable

### DIFF
--- a/helm/thingsboard/templates/component-service.yaml
+++ b/helm/thingsboard/templates/component-service.yaml
@@ -17,7 +17,11 @@
 {{ $values := .Values -}}
 {{- $releaseName := .Release.Name -}}
 {{- $labels := include "thingsboard.labels" . -}}
-{{- range tuple "mqtt" "http" "coap" "webui" -}}
+{{- $components := list "http" "coap" "webui" -}}
+{{- if .Values.mqtt.service.enabled -}}
+  {{- $components = append $components "mqtt" -}}
+{{- end -}}
+{{- range $components -}}
   {{- $component := . -}}
   {{- $componentValues := index $values $component -}}
 

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -196,6 +196,7 @@ mqtt:
   podSecurityContext: {}
   securityContext: {}
   service:
+    enabled: true
     ipv6: false
     type: ClusterIP
     port: 8883


### PR DESCRIPTION
## Summary

Add `mqtt.service.enabled` flag to allow disabling the MQTT Service creation in Thingsboard chart. When disabled, external charts (like EVP chart) can manage the MQTT service independently.

## What's Changed

- Add `mqtt.service.enabled: true` to values.yaml (default maintains current behavior)
- Conditionally render component-service.yaml MQTT service based on flag
- When disabled, enables external charts to manage MQTT service

## Why

Enables seamless MQTT component migration and hot-swap capabilities without disrupting clients. Allows gradual transition from Thingsboard-managed MQTT to EVP-managed MQTT.

## Test Plan

- [ ] Verify MQTT service is created when `mqtt.service.enabled: true` (default)
- [ ] Verify MQTT service is NOT created when `mqtt.service.enabled: false`
- [ ] Verify other services (http, coap, webui) are created normally in both cases
- [ ] Verify helm template renders correctly with both flag values

🤖 Generated with [Claude Code](https://claude.com/claude-code)